### PR TITLE
print index when listing attributes

### DIFF
--- a/mdevctl
+++ b/mdevctl
@@ -805,11 +805,10 @@ case $cmd in
 
                     count=$(( $(get_attr_length) - 1 ))
                     if [ $count -ge 0 ]; then
-                        echo -n "  Attrs: "
+                        echo "  Attrs: "
                         for i in $(seq 0 $count); do
-                            echo -n "$(get_attr_index_raw $i) "
+                            echo "    @{$i}: $(get_attr_index_raw $i)"
                         done
-                        echo
                     fi
                 done
             done


### PR DESCRIPTION
This makes it easier to figure out the index of an attribute
one might want to modify.

Before:

783e6dbb-ea0e-411f-94e2-717eaad438bf matrix vfio_ap-passthrough manual
  Attrs: {"assign_adapter":["5","6"]} {"assign_domain":["4","0xab"]}

After:

783e6dbb-ea0e-411f-94e2-717eaad438bf matrix vfio_ap-passthrough manual
  Attrs:
    @{0}: {"assign_adapter":["5","6"]}
    @{1}: {"assign_domain":["4","0xab"]}

Signed-off-by: Cornelia Huck <cohuck@redhat.com>