### PR TITLE
simplify attribute handling

### DIFF
--- a/README
+++ b/README
@@ -158,16 +158,21 @@ Example:
 783e6dbb-ea0e-411f-94e2-717eaad438bf matrix vfio_ap-passthrough manual
 
 Add some attributes:
-# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_adapter --value=5,6
-# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_domain --value=4,0xab
-# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_control_domain --value=4,0xab
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_adapter --value=5
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_adapter --value=6
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_domain --value=0xab
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_control_domain --value=0xab
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_domain --value=4
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --addattr=assign_control_domain --value=4
 # mdevctl list -d
 783e6dbb-ea0e-411f-94e2-717eaad438bf matrix vfio_ap-passthrough manual
   Attrs:
-    @{0}: {"assign_adapter":["5","6"]}
-    @{1}: {"assign_domain":["4","0xab"]}
-    @{2}: {"assign_control_domain":["4","0xab"]}
-
+    @{0}: {"assign_adapter":"5"}
+    @{1}: {"assign_adapter":"6"}
+    @{2}: {"assign_domain":"0xab"}
+    @{3}: {"assign_control_domain":"0xab"}
+    @{4}: {"assign_domain":"4"}
+    @{5}: {"assign_control_domain":"4"}
 Dump the JSON configuration:
 # mdevctl list -d -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --dumpjson
 {
@@ -175,33 +180,36 @@ Dump the JSON configuration:
   "start": "manual",
   "attrs": [
     {
-      "assign_adapter": [
-        "5",
-        "6"
-      ]
+      "assign_adapter": "5"
     },
     {
-      "assign_domain": [
-        "4",
-        "0xab"
-      ]
+      "assign_adapter": "6"
     },
     {
-      "assign_control_domain": [
-        "4",
-        "0xab"
-      ]
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
     }
   ]
 }
 
-Remove an attribute:
-# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --delattr --index=2
+Remove some attributes:
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --delattr --index=5
+# mdevctl modify -u 783e6dbb-ea0e-411f-94e2-717eaad438bf --delattr --index=4
 # mdevctl list -d
 783e6dbb-ea0e-411f-94e2-717eaad438bf matrix vfio_ap-passthrough manual
   Attrs:
-    @{0}: {"assign_adapter":["5","6"]}
-    @{1}: {"assign_domain":["4","0xab"]}
+    @{0}: {"assign_adapter":"5"}
+    @{1}: {"assign_adapter":"6"}
+    @{2}: {"assign_domain":"0xab"}
+    @{3}: {"assign_control_domain":"0xab"}
 
 Define an mdev device from a file:
 # cat vfio_ap_device.json
@@ -210,15 +218,13 @@ Define an mdev device from a file:
   "start": "manual",
   "attrs": [
     {
-      "assign_adapter": [
-        "5"
-      ]
+      "assign_adapter": "5"
     },
     {
-      "assign_domain": [
-        "0x47",
-        "0xff"
-      ]
+      "assign_domain": "0x47"
+    },
+    {
+      "assign_domain": "0xff"
     }
   ]
 }
@@ -227,13 +233,15 @@ e2e73122-cc39-40ee-89eb-b0a47d334cae
 # mdevctl list -d
 783e6dbb-ea0e-411f-94e2-717eaad438bf matrix vfio_ap-passthrough manual
   Attrs:
-    @{0}: {"assign_adapter":["5","6"]}
-    @{1}: {"assign_domain":["4","0xab"]}
+    @{0}: {"assign_adapter":"5"}
+    @{1}: {"assign_adapter":"6"}
+    @{2}: {"assign_domain":"0xab"}
+    @{3}: {"assign_control_domain":"0xab"}
 e2e73122-cc39-40ee-89eb-b0a47d334cae matrix vfio_ap-passthrough manual
   Attrs:
-    @{0}: {"assign_adapter":["5"]}
-    @{1}: {"assign_domain":["0x47","0xff"]}
-
+    @{0}: {"assign_adapter":"5"}
+    @{1}: {"assign_domain":"0x47"}
+    @{2}: {"assign_domain":"0xff"}
 
 See 'mdevctl --help' for more information.
 

--- a/mdevctl
+++ b/mdevctl
@@ -15,12 +15,7 @@ config={}
 attrs=[]
 
 jsonify() {
-    if [ $(echo ${1} | awk -F "," '{print NF-1}') -eq 0 ]; then
-        echo \"${1}\"
-    else
-        echo [$( echo ${1} | tr ',' '\n' | xargs -i echo \"{}\" | \
-              tr '\n' ',' | sed -e 's/,$//')]
-   fi
+    echo \"${1}\"
 }
 
 del_config_key() {
@@ -51,12 +46,7 @@ has_config_key() {
 get_config_key() {
     key=${1}
 
-    type=$(echo $config | jq -r -M --arg key "$key" '.[$key] | type')
-    if [ $type == "string" ]; then
-        echo $config | jq -r -M --arg key "$key" '.[$key]'
-    elif [ $type == "array" ]; then
-        echo $config | jq -r -M --arg key "$key" '.[$key][]'
-    fi
+    echo $config | jq -r -M --arg key "$key" '.[$key]'
 }
 
 config_file() {
@@ -129,12 +119,7 @@ get_attr_index_value() {
         index=${1}
     fi
 
-    type=$(echo $attrs | jq -r -M --argjson i $index '.[$i] | .[] | type')
-    if [ $type == "string" ]; then
-        echo $attrs | jq -r -M --argjson i $index '.[$i] | .[]'
-    elif [ $type == "array" ]; then
-        echo $attrs | jq -r -M --argjson i $index '.[$i] | .[][]'
-    fi
+    echo $attrs | jq -r -M --argjson i $index '.[$i] | .[]'
 }
 
 get_attr_index_raw() {
@@ -263,14 +248,13 @@ start_mdev() {
                     remove_mdev $uuid
                     return 1
                 fi
-                for val in $(get_attr_index_value $i); do
-                    echo -e $val > $mdev_base/$uuid/$attr
-                    if [ $? -ne 0 ]; then
-                        echo "Failed to write $val to attribute $attr" >&2
-                        remove_mdev $uuid
-                        return 1
-                    fi
-                done
+                val=$(get_attr_index_value $i)
+                echo -e $val > $mdev_base/$uuid/$attr
+                if [ $? -ne 0 ]; then
+                    echo "Failed to write $val to attribute $attr" >&2
+                    remove_mdev $uuid
+                    return 1
+                fi
             done
         fi
         $print_uuid
@@ -344,9 +328,9 @@ modify		Modify the config for a defined mdev device.  Options:
 		ATTRIBUTE can be added or removed, which correlates to a
 		sysfs attribute under the created device.  Unless an INDEX
 		value is provided, operations are performed at the end of
-		the attribute list.  VALUE may be specified as singly or
-		seprated by commas.  Upon device start, mdevctl will through
-		each value of each attribute in order, writing the value into
+		the attribute list.  VALUE is to be specified in the format
+		that is accepted by the attribute.  Upon device start, mdevctl
+		will go through each attribute in order, writing the value into
 		the corresponding sysfs attribute for the device.  The startup
 		mode of the device can also be selected, auto or manual.
 		Running devices are unaffected by this command.


### PR DESCRIPTION
Instead of automatically parsing a list of values for an attribute
into an array and then writing each value to the attribute
individually, just write the value given to the attribute as-is.

While this makes specifying lists of values a bit more tedious
(although it is probably better to write a config file directly
for complex configurations anyway), it gives us some benefits:
- no weird escaping if you explicitly want to specify a comma-
  separated list of values for an attribute
- you can delete one value for an attribute explicitly (by index),
  no need to delete the whole range and re-add
- slightly simpler parsing code

Note: existing configs with attributes are not converted.

Signed-off-by: Cornelia Huck <cohuck@redhat.com>