### PR TITLE
lsmdev - add the alternative name to the man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ install:
 	ln -s mdevctl $(DESTDIR)$(SBINDIR)/lsmdev
 	mkdir -p $(DESTDIR)$(MANDIR)/man8
 	install -m 644 mdevctl.8 $(DESTDIR)$(MANDIR)/man8/
+	ln -s mdevctl.8  $(DESTDIR)$(MANDIR)/man8/lsmdev.8
 
 clean:
 	rm -f mdevctl.spec *.src.rpm noarch/*.rpm *.tar.gz

--- a/mdevctl.8
+++ b/mdevctl.8
@@ -1,7 +1,7 @@
 .\" mdevctl - Mediated device management utility
 .TH mdevctl 8
 .SH NAME
-mdevctl - Mediated device management utility
+mdevctl, lsmdev \- Mediated device management utility
 .SH SYNOPSIS
 \fBmdevctl\fR {COMMAND} [OPTIONS...]\fR
 


### PR DESCRIPTION
lsmdev was installed as symlinked alternative name, but up until this patch
is neither mentioned in the man pages NAME section of mdevctl.8 nor has a
symlinked man page file that would allof to find `man lsmdev` the page.

Found while trying to package mdevctl for [Debian/Ubuntu](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=945230)