### PR TITLE
Fix the Makefile so that it works on CentOS 7 as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ archive: files mdevctl.spec
 mdevctl.spec: tag mdevctl.spec.in files
 	sed -e 's:#VERSION#:$(VERSION):g' < mdevctl.spec.in > mdevctl.spec
 	PREV=""; \
-	for TAG in `git tag --sort=version:refname | tac`; do \
+	for TAG in `git tag | sort -Vr`; do \
 	    if [ -n "$$PREV" ]; then \
 	    git log --format="- %h (\"%s\")" $$TAG..$$PREV >> mdevctl.spec; \
 	    fi; \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ mdevctl.spec: tag mdevctl.spec.in files
 	    if [ -n "$$PREV" ]; then \
 	    git log --format="- %h (\"%s\")" $$TAG..$$PREV >> mdevctl.spec; \
 	    fi; \
-	    git log -1 --format="%n* %cd %aN <%ae> - $$TAG-1" --date="format:%a %b %d %Y" $$TAG >> mdevctl.spec; \
+	    isodate=`git log -1 --format="%cd" --date=iso`; \
+	    changelog_date=`date --date="$$isodate" +"%a %b %d %Y"`; \
+	    git log -1 --format="%n* $$changelog_date %aN <%ae> - $$TAG-1" $$TAG >> mdevctl.spec; \
 	    PREV=$$TAG; \
 	done; \
 	git log --format="- %h (\"%s\")" $$TAG >> mdevctl.spec


### PR DESCRIPTION
Currently the Makefile uses some Git >2.0 features not available on CentOS-7, making it unable to build the rpms from source. By using the common Linux OS binaries, this can be fix in a straightforward manner.