### PR TITLE
man: Point --verbose to the 'list' command rather than 'types'

### DIFF
--- a/mdevctl.8
+++ b/mdevctl.8
@@ -102,7 +102,7 @@ Valid for the \fBmodify\fR command.
 \fB-v|--verbose\fR
 .RS 4
 Increase output verbosity, currently only adds attribute output to the
-\fBtypes\fR command.
+\fBlist\fR command.
 .RE
 
 .SH COMMANDS


### PR DESCRIPTION
Signed-off-by: Erik Skultety <eskultet@redhat.com>