### PR TITLE
Remove never used 'available' option

### DIFF
--- a/mdevctl
+++ b/mdevctl
@@ -540,10 +540,6 @@ while true; do
             defined=y
             shift 1
             ;;
-        -a|--available)
-            available=y
-            shift 1
-            ;;
         -v|--verbose)
             verbose=y
             shift 1


### PR DESCRIPTION
As reported by coverity scan:

Defect type: SHELLCHECK_WARNING
1. /usr/sbin/mdevctl:544:13: warning: available appears unused. Verify use (or export if used externally). [SC2034]

This also fixes a conflict between `auto` and `available` short options,
with both using -a for it.

closes: #24

Signed-off-by: Eduardo Lima (Etrunko) <etrunko@redhat.com>