### PR TITLE
mdevctl: fix cleanup on error when writing to attribute

### DIFF
--- a/mdevctl
+++ b/mdevctl
@@ -232,8 +232,9 @@ create_mdev() {
         return 1
     fi
 
-    echo "$uuid" > "$parent_base/$parent/mdev_supported_types/$type/create"
-    if [ $? -ne 0 ]; then
+    cret=0
+    echo "$uuid" > "$parent_base/$parent/mdev_supported_types/$type/create" || cret=$?
+    if [ $cret -ne 0 ]; then
         echo "Error creating mdev type $type on $parent" >&2
         return 1
     fi
@@ -288,8 +289,9 @@ remove_mdev() {
         return 1
     fi
 
-    echo 1 > "$mdev_base/$uuid/remove"
-    if [ $? -ne 0 ]; then
+    rret=0
+    echo 1 > "$mdev_base/$uuid/remove" || rret=$?
+    if [ $rret -ne 0 ]; then
         echo "Error removing device $uuid" >&2
         return 1
     fi

--- a/mdevctl
+++ b/mdevctl
@@ -261,8 +261,9 @@ start_mdev() {
                     return 1
                 fi
                 val=$(get_attr_index_value $i)
-                echo -e "$val" > "$mdev_base/$uuid/$attr"
-                if [ $? -ne 0 ]; then
+                wret=0
+                echo -e "$val" > "$mdev_base/$uuid/$attr" || wret=$?
+                if [ $wret -ne 0 ]; then
                     echo "Failed to write $val to attribute $attr" >&2
                     remove_mdev "$uuid"
                     return 1


### PR DESCRIPTION
If a vfio driver returns e.g. a write error while attribute data is
being populated into the system mdevctl exits without cleanup.
Here is an example with vfio-ap try to use the same queue resource

$ mdevctl list -dv
77773333-ea0e-4911-4911-aaaaaaaaaaaa matrix vfio_ap-passthrough manual
  Attrs:
    @{0}: {"assign_adapter":"7"}
    @{1}: {"assign_domain":"3"}
77773333-ea0e-4911-4911-eeeeeeeeeeee matrix vfio_ap-passthrough manual
  Attrs:
    @{0}: {"assign_adapter":"7"}
    @{1}: {"assign_domain":"3"}
$ mdevctl start -u 77773333-ea0e-4911-4911-aaaaaaaaaaaa
$ mdevctl list -d
77773333-ea0e-4911-4911-aaaaaaaaaaaa matrix vfio_ap-passthrough manual (active)
77773333-ea0e-4911-4911-eeeeeeeeeeee matrix vfio_ap-passthrough manual
$ mdevctl start -u 77773333-ea0e-4911-4911-eeeeeeeeeeee
/usr/sbin/mdevctl: line 264: echo: write error: Address already in use
$ cat /sys/devices/vfio_ap/matrix/77773333-ea0e-4911-4911-eeeeeeeeeeee/matrix
07.
$ mdevctl list -d
77773333-ea0e-4911-4911-aaaaaaaaaaaa matrix vfio_ap-passthrough manual (active)
77773333-ea0e-4911-4911-eeeeeeeeeeee matrix vfio_ap-passthrough manual (active)

Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>