### PR TITLE
Bug fix + version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ SBINDIR=$(PREFIX)/sbin
 CONFDIR=/etc/mdevctl.d
 MANDIR=$(PREFIX)/share/man
 NAME=mdevctl
-VERSION=0.$(shell git rev-list --count HEAD)
-NVFMT=$(NAME)-$(VERSION)
+MDEVCTL_VER=$(shell ./mdevctl version)
+REVLIST_VER=0.$(shell git rev-list --count HEAD)
+NEXT_VER=0.$(shell echo $$(( $(shell git rev-list --count HEAD) + 1 )) )
+NVFMT=$(NAME)-$(REVLIST_VER)
 
 files: mdevctl 60-mdevctl.rules mdevctl.8 \
 	Makefile COPYING README.md mdevctl.spec.in
@@ -15,7 +17,7 @@ archive: files mdevctl.spec
 	gzip -f -9 $(NVFMT).tar
 
 mdevctl.spec: tag mdevctl.spec.in files
-	sed -e 's:#VERSION#:$(VERSION):g' < mdevctl.spec.in > mdevctl.spec
+	sed -e 's:#VERSION#:$(shell ./mdevctl version):g' < mdevctl.spec.in > mdevctl.spec
 	PREV=""; \
 	for TAG in `git tag --sort=version:refname | tac`; do \
 	    if [ -n "$$PREV" ]; then \
@@ -47,4 +49,4 @@ clean:
 	rm -f mdevctl.spec *.src.rpm noarch/*.rpm *.tar.gz
 
 tag:
-	git tag -l $(VERSION) | grep -q $(VERSION) || git tag $(VERSION)
+	[ $(MDEVCTL_VER) == $(REVLIST_VER) ] || (sed -i "s/^version=.*/version=\"$(NEXT_VER)\"/" mdevctl && git add mdevctl && git commit -m "Automatic version commit for tag $(NEXT_VER)" && git tag $(NEXT_VER))

--- a/mdevctl
+++ b/mdevctl
@@ -3,6 +3,7 @@
 persist_base=/etc/mdevctl.d
 mdev_base=/sys/bus/mdev/devices
 parent_base=/sys/class/mdev_bus
+version="0.69"
 
 # Alias 'lsmdev' to 'mdevctl list'
 if [ $(basename $0) == "lsmdev" ]; then
@@ -382,6 +383,7 @@ types		List mdev types.  Options:
 		Specifying a PARENT lists only the types provided by the given
 		parent device.  The dumpjson option provides output in machine
 		readable JSON format.
+version		Print mdevctl version.
 EOF
     exit 1
 }
@@ -434,6 +436,12 @@ case ${1} in
     --help|-h|-?)
         usage
         ;;
+    version)
+        cmd="$1"
+        OPTIONS=""
+        LONGOPTS=""
+        shift
+	;;
     define)
         cmd="$1"
         OPTIONS="u:p:t:a"
@@ -560,6 +568,9 @@ if [ $# -ne 0 ]; then
 fi
 
 case "$cmd" in
+    version)
+        echo $version
+        ;;
     define)
         if [ -n "$jsonfile" ]; then
             if [ ! -r "$jsonfile" ]; then

--- a/mdevctl
+++ b/mdevctl
@@ -418,7 +418,7 @@ case ${1} in
                 fi
 
                 if [ "$(get_config_key start)" == "auto" ]; then
-                    create_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
+                    start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
                     if [ $? -ne 0 ]; then
                         echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
                         # continue...

--- a/mdevctl.8
+++ b/mdevctl.8
@@ -178,6 +178,12 @@ parents, all of them will be removed unless restricted to a single parent.
 Running devices are unaffected by this command.
 .RE
 
+.PP
+\fBversion\fR
+.RS 4
+Print mdevctl version.
+.RE
+
 .SH "NOTE ON DEVICE SPECIFICATION"
 
 For a given UUID, only one device with that UUID may be running at the


### PR DESCRIPTION
1) Fix an obvious bug where the path we call when a parent device appears only creates the mdev without applying attributes.

2) Add version command support.  The 'tag' make target will now modify the version variable in the mdevctl script, commit the change, and add the matching tag.  This is not too unlike kernel versions, where the Makefile is updated and a tag added to that commit with a matching version.