### PR TITLE
Invoking External Scripts for Device Events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREFIX=/usr
 UDEVDIR=$(shell pkg-config --variable=udevdir udev)
 SBINDIR=$(PREFIX)/sbin
 CONFDIR=/etc/mdevctl.d
+CALLOUT_CMD_DIR=$(CONFDIR)/callouts/command.d
+CALLOUT_NOTIFIER_DIR=$(CONFDIR)/notification/notifiers.d
 MANDIR=$(PREFIX)/share/man
 NAME=mdevctl
 MDEVCTL_VER=$(shell ./mdevctl version)
@@ -44,6 +46,8 @@ install:
 	mkdir -p $(DESTDIR)$(MANDIR)/man8
 	install -m 644 mdevctl.8 $(DESTDIR)$(MANDIR)/man8/
 	ln -sf mdevctl.8  $(DESTDIR)$(MANDIR)/man8/lsmdev.8
+	mkdir -p $(DESTDIR)$(CALLOUT_CMD_DIR)
+	mkdir -p $(DESTDIR)$(CALLOUT_NOTIFIER_DIR)
 
 clean:
 	rm -f mdevctl.spec *.src.rpm noarch/*.rpm *.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SBINDIR=$(PREFIX)/sbin
 CONFDIR=/etc/mdevctl.d
 CALLOUT_CMD_DIR=$(CONFDIR)/callouts/command.d
 CALLOUT_NOTIFIER_DIR=$(CONFDIR)/notification/notifiers.d
+CALLOUT_GET_DIR=$(CONFDIR)/callouts/get.d
 MANDIR=$(PREFIX)/share/man
 NAME=mdevctl
 MDEVCTL_VER=$(shell ./mdevctl version)
@@ -48,6 +49,7 @@ install:
 	ln -sf mdevctl.8  $(DESTDIR)$(MANDIR)/man8/lsmdev.8
 	mkdir -p $(DESTDIR)$(CALLOUT_CMD_DIR)
 	mkdir -p $(DESTDIR)$(CALLOUT_NOTIFIER_DIR)
+	mkdir -p $(DESTDIR)$(CALLOUT_GET_DIR)
 
 clean:
 	rm -f mdevctl.spec *.src.rpm noarch/*.rpm *.tar.gz

--- a/mdevctl
+++ b/mdevctl
@@ -609,69 +609,50 @@ case "$cmd" in
                 exit 1
             fi
 
-            write_config "$persist_base/$parent/$uuid"
-            if [ $? -ne 0 ]; then
-                exit 1
-            fi
+        else
 
-            $print_uuid
-            exit 0
-        fi
-
-        if [ -n "$uuid" ]; then
-            if [ -z "$parent" ]; then
-                if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
-                    usage
+            if [ -n "$uuid" ]; then
+                if [ -z "$parent" ]; then
+                    if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
+                        usage
+                    fi
+                    parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
+                    type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
                 fi
 
-                parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
-                type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
+                if [ -e "$persist_base/$parent/$uuid" ]; then
+                    echo "Device $uuid on $parent already defined, try modify?" >&2
+                    exit 1
+                fi
+            else
+                uuid=$(unique_uuid)
+                print_uuid="echo $uuid"
             fi
 
-            if [ -e "$persist_base/$parent/$uuid" ]; then
-                echo "Device $uuid on $parent already defined, try modify?" >&2
-                exit 1
+            if [ -z "$parent" ]; then
+                usage
             fi
-        else
-            uuid=$(unique_uuid)
-            print_uuid="echo $uuid"
-        fi
 
-        if [ -z "$parent" ]; then
-            usage
-        fi
+            if [ -z "$type" ]; then
+                usage
+            fi
 
-        if [ -z "$type" ]; then
-            usage
-        fi
+            if [ -n "$auto" ]; then
+                start="auto"
+            else
+                start="manual"
+            fi
 
-        if [ -n "$auto" ]; then
-            start="auto"
-        else
-            start="manual"
-        fi
+            set -o errexit
 
-        set -o errexit
-
-        mkdir -p "$persist_base/$parent"
-        set_config_key mdev_type "$type"
-        set_config_key start "$start"
-        write_config "$persist_base/$parent/$uuid"
-        if [ $? -eq 0 ]; then
-            $print_uuid
+            mkdir -p "$persist_base/$parent"
+            set_config_key mdev_type "$type"
+            set_config_key start "$start"
         fi
         ;;
     undefine)
         if [ -z "$uuid" ]; then
             usage
-        fi
-
-        set -o errexit
-
-        if [ -n "$parent" ]; then
-            rm -f "$persist_base/$parent/$uuid"
-        else
-            find "$persist_base" -name "$uuid" -type f | xargs rm -f
         fi
         ;;
     modify)
@@ -743,8 +724,6 @@ case "$cmd" in
 
             del_attr_index "$index"
         fi
-
-        write_config "$file"
         ;;
     start)
         set -o errexit
@@ -778,73 +757,65 @@ case "$cmd" in
 
             type="$(get_config_key mdev_type)"
 
-            start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-            exit $?
-        fi
+        else
 
-        # We don't implement a placement policy
-        if [ -n "$type" ] && [ -z "$parent" ]; then
-            usage
-        fi
-
-        # The device is not fully specified without TYPE, we must find
-        # a config file, with optional PARENT for disambiguation
-        if [ -z "$type" ] && [ -n "$uuid" ]; then
-            count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
-            if [ "$count" -eq 0 ]; then
-                echo "Config for $uuid does not exist, define it first?" >&2
-                exit 1
-            elif [ "$count" -gt 1 ]; then
-                if [ -z "$parent" ] || [ ! -e "$persist_base/$parent/$uuid" ]; then
-                    echo "Multiple configs found for $uuid, specify a parent" >&2
-                    exit 1
-                fi
-                file="$persist_base/$parent/$uuid"
-            else
-                file=$(find "$persist_base" -name "$uuid" -type f)
-                if [ -n "$parent" ]; then
-                    cur_parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
-                    if [ "$cur_parent" != "$parent" ]; then
-                        echo "Config for $parent/$uuid does not exist, define it first?" >&2
-                        exit 1
-                    fi
-                fi
-            fi
-
-            read_config "$file"
-            if [ $? -ne 0 ]; then
-                echo "Config file $file invalid" >&2
-                exit 1
-            fi
-
-            if [ -z "$parent" ]; then
-                parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
-            fi
-
-            type="$(get_config_key mdev_type)"
-        fi
-
-        if [ -z "$uuid" ]; then
-            # Device must be full specified otherwise for generated UUID
-            if [ -z "$parent" ] || [ -z "$type" ]; then
-                echo "Device is insufficiently specified" >&2
+            # We don't implement a placement policy
+            if [ -n "$type" ] && [ -z "$parent" ]; then
                 usage
             fi
-            uuid=$(unique_uuid)
-            print_uuid="echo $uuid"
-        fi
 
-        start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-        exit $?
+            # The device is not fully specified without TYPE, we must find
+            # a config file, with optional PARENT for disambiguation
+            if [ -z "$type" ] && [ -n "$uuid" ]; then
+                count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
+                if [ "$count" -eq 0 ]; then
+                    echo "Config for $uuid does not exist, define it first?" >&2
+                    exit 1
+                elif [ "$count" -gt 1 ]; then
+                    if [ -z "$parent" ] || [ ! -e "$persist_base/$parent/$uuid" ]; then
+                        echo "Multiple configs found for $uuid, specify a parent" >&2
+                        exit 1
+                    fi
+                    file="$persist_base/$parent/$uuid"
+                else
+                    file=$(find "$persist_base" -name "$uuid" -type f)
+                    if [ -n "$parent" ]; then
+                        cur_parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
+                        if [ "$cur_parent" != "$parent" ]; then
+                            echo "Config for $parent/$uuid does not exist, define it first?" >&2
+                            exit 1
+                        fi
+                    fi
+                fi
+
+                read_config "$file"
+                if [ $? -ne 0 ]; then
+                    echo "Config file $file invalid" >&2
+                    exit 1
+                fi
+
+                if [ -z "$parent" ]; then
+                    parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
+                fi
+
+                type="$(get_config_key mdev_type)"
+            fi
+
+            if [ -z "$uuid" ]; then
+                # Device must be full specified otherwise for generated UUID
+                if [ -z "$parent" ] || [ -z "$type" ]; then
+                    echo "Device is insufficiently specified" >&2
+                    usage
+                fi
+                uuid=$(unique_uuid)
+                print_uuid="echo $uuid"
+            fi
+        fi
         ;;
     stop)
         if [ -z "$uuid" ]; then
             usage
         fi
-
-        set -o errexit
-
-        remove_mdev "$uuid"
         ;;
     list)
         json="[]"
@@ -1013,5 +984,36 @@ case "$cmd" in
         else
             echo -en "$txt"
         fi
+        ;;
+esac
+
+
+case "$cmd" in
+    define)
+        write_config "$persist_base/$parent/$uuid"
+        if [ $? -eq 0 ]; then
+            $print_uuid
+        fi
+        ;;
+    undefine)
+        set -o errexit
+
+        if [ -n "$parent" ]; then
+            rm -f "$persist_base/$parent/$uuid"
+        else
+            find "$persist_base" -name "$uuid" -type f | xargs rm -f
+        fi
+        ;;
+    modify)
+        write_config "$file"
+        ;;
+    start)
+        start_mdev "$uuid" "$parent" "$type" "$print_uuid"
+        exit $?
+        ;;
+    stop)
+        set -o errexit
+
+        remove_mdev "$uuid"
         ;;
 esac

--- a/mdevctl
+++ b/mdevctl
@@ -314,6 +314,153 @@ unique_uuid() {
     echo "$uuid"
 }
 
+callout_script="$persist_base/callouts/command.d"
+callout_notification="$persist_base/notification/notifiers.d"
+
+state="none"
+
+dir_is_empty() {
+    path="$1"
+
+    if [ -n "$(ls -A "$path")" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+get_callout_script() {
+    path="$1"
+
+    if [ "$script" != "" ]; then
+        return 0
+    else
+        for s in $path/*; do
+            script=$($s -t "$type")
+            if [ "$script" != "" ]; then
+                return 0
+            fi
+        done
+    fi
+
+    return 1
+}
+
+# Not all commands provide all necessary info for the callouts 
+# Some sysfs devices need some extra work
+get_device_parameters() {
+    uuid="$1"
+    parent="$2"
+    type="$3"
+
+    if [ -z "$parent" ]; then
+        count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
+        if [ "$count" -eq 1 ]; then
+            file_path=$(echo $(find "$persist_base" -name "$uuid" -type f))
+            parent=$(basename $(realpath "$file_path" | sed -s "s/\/$uuid//"))
+        elif [ "$count" -eq 0 ]; then
+            if [ -d "$mdev_base/$uuid" ]; then
+                parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
+                type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
+            else
+                return 1
+            fi
+        else
+            return 1
+        fi
+    fi
+    
+    if [ $(echo "$config" | jq 'length') -eq 0 ]; then 
+        # Start and stop a device without defined config file
+        # $config was not assigned before initial callout and config file does not exists
+        # We need to assigned $config with parameters passed by the user
+        if [ ! -e "$persist_base/$parent/$uuid" ]; then
+            set_config_key mdev_type "$type"
+            set_config_key start 'manual'
+        else
+        # Undefine and stop a device
+        # $config was not assigned before initial callout and config file exists
+        # We need to read the config file to assign $config and $attrs
+            read_config "$persist_base/$parent/$uuid"
+        fi
+    fi
+
+    if [ -z "$type" ]; then
+        type="$(get_config_key mdev_type)"
+    fi
+
+    return 0
+}
+
+callout() {
+    event="$1"
+    action="$2"
+    uuid="$3"
+    parent="$4"
+    type="$5"
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    if dir_is_empty "$callout_script"; then
+        return 0
+    fi
+
+    if ! get_callout_script "$callout_script"; then
+        return 0
+    fi
+
+    # Save content of $config to $conf variable
+    # Allow scripts to check the device configuration 
+    # even after the device removed from the system
+    if [ "$conf" == "" ]; then
+        conf=$(dump_config)
+    fi
+
+    set -o pipefail
+    
+    echo "$conf" | $script -e "$event" -a "$action" -s "$state" -u "$uuid" -p "$parent" 2>&1 > /dev/null |
+    (sed "s/^/$(basename $(realpath "$script")): /" >&2)
+
+    return $?
+}
+
+callout_notify() {
+    action="$1"
+    uuid="$2"
+    parent="$3"
+    type="$4"
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    if dir_is_empty "$callout_notification"; then
+        return 0
+    fi
+
+    # Save content of $config to $conf variable
+    # Allow scripts to check the device configuration 
+    # even after the device removed from the system
+    if [ "$conf" == "" ]; then
+        conf=$(dump_config)
+    fi
+
+    set -o pipefail
+
+    for n in $callout_notification/*; do
+        echo "$conf" | $n -e "notify" -a "$action" -s "$state" -u "$uuid" -p "$parent" 2>&1 |
+        (sed "s/^/$(basename $(realpath "$n")): /")
+    done
+
+    return 0
+}
+
 usage() {
     cat >&2 <<EOF
 Usage: $(basename $0) {COMMAND} [options...]
@@ -423,10 +570,19 @@ case ${1} in
                 fi
 
                 if [ "$(get_config_key start)" == "auto" ]; then
-                    start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
-                    if [ $? -ne 0 ]; then
-                        echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
-                        # continue...
+                    callout "pre" "start" "$uuid" "$parent" "$(get_config_key mdev_type)" 2>&1 | systemd-cat -t $(basename $0) -p err
+                    if [ $? -eq 0 ]; then
+                        start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
+                        if [ $? -ne 0 ]; then
+                            echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
+                            # continue...
+
+                            state="failure"
+                        else
+                            state="success"
+                        fi
+
+                        callout "post" "start" "$uuid" "$parent" "$(get_config_key mdev_type)" 2>&1 | systemd-cat -t $(basename $0) -p err
                     fi
                 fi
             fi
@@ -987,6 +1143,13 @@ case "$cmd" in
         ;;
 esac
 
+get_device_parameters "$uuid" "$parent" "$type"
+
+callout "pre" "$cmd" "$uuid" "$parent" "$type"
+if [ $? -ne 0 ]; then
+    callout_notify "$cmd" "$uuid" "$parent" "$type"
+    exit 0
+fi
 
 case "$cmd" in
     define)
@@ -996,8 +1159,6 @@ case "$cmd" in
         fi
         ;;
     undefine)
-        set -o errexit
-
         if [ -n "$parent" ]; then
             rm -f "$persist_base/$parent/$uuid"
         else
@@ -1009,11 +1170,17 @@ case "$cmd" in
         ;;
     start)
         start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-        exit $?
         ;;
     stop)
-        set -o errexit
-
         remove_mdev "$uuid"
         ;;
 esac
+if [ $? -eq 0 ]; then
+    state="success"
+else
+    state="failure"
+fi
+
+callout "post" "$cmd" "$uuid" "$parent" "$type"
+
+callout_notify "$cmd" "$uuid" "$parent" "$type"

--- a/mdevctl
+++ b/mdevctl
@@ -316,8 +316,26 @@ unique_uuid() {
 
 callout_script="$persist_base/callouts/command.d"
 callout_notification="$persist_base/notification/notifiers.d"
+callout_get_attr="$persist_base/callouts/get.d"
 
 state="none"
+get_attr=[]
+
+build_config() {
+    uuid="$1"
+    parent="$2"
+    type="$3"
+
+    set_config_key mdev_type "$type"
+    set_config_key start 'manual'
+
+    callout_get "get" "attributes" "$uuid" "$parent" "$type"
+    if [ $? -eq 0 ]; then
+        if [ "$get_attr" != [{}] ]; then
+            attrs=$get_attr
+        fi
+    fi
+}
 
 dir_is_empty() {
     path="$1"
@@ -375,8 +393,7 @@ get_device_parameters() {
         # $config was not assigned before initial callout and config file does not exists
         # We need to assigned $config with parameters passed by the user
         if [ ! -e "$persist_base/$parent/$uuid" ]; then
-            set_config_key mdev_type "$type"
-            set_config_key start 'manual'
+            build_config "$uuid" "$parent" "$type"
         else
         # Undefine and stop a device
         # $config was not assigned before initial callout and config file exists
@@ -424,6 +441,35 @@ callout() {
     
     echo "$conf" | $script -e "$event" -a "$action" -s "$state" -u "$uuid" -p "$parent" 2>&1 > /dev/null |
     (sed "s/^/$(basename $(realpath "$script")): /" >&2)
+
+    return $?
+}
+
+callout_get() {
+    local event="$1"
+    local action="$2"
+    local uuid="$3"
+    local parent="$4"
+    local type="$5"
+    local script=""
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    if dir_is_empty "$callout_get_attr"; then
+        return 0
+    fi
+
+    if ! get_callout_script "$callout_get_attr"; then
+        return 0
+    fi
+
+    set -o pipefail
+
+    get_attr=$($script -e "$event" -a "$action" -s "none" -u "$uuid" -p "$parent")
 
     return $?
 }
@@ -804,6 +850,17 @@ case "$cmd" in
             mkdir -p "$persist_base/$parent"
             set_config_key mdev_type "$type"
             set_config_key start "$start"
+
+            if [ -e "$mdev_base/$uuid" ]; then
+                callout_get "get" "attributes" "$uuid" "$parent" "$type"
+                if [ $? -eq 0 ]; then
+                    if [ "$get_attr" != [{}] ]; then
+                        attrs=$get_attr
+                    fi
+                else
+                    exit 1
+                fi
+            fi
         fi
         ;;
     undefine)
@@ -1047,6 +1104,20 @@ case "$cmd" in
 
                 json_tmp="{\"$p\":[{\"$u\":{\"mdev_type\":\"$type\"}}]}"
                 txt+="$u $p $type"
+
+                if [ -n "$dumpjson" ]; then
+                    callout_get "get" "attributes" "$u" "$p" "$type"
+                    if [ $? -eq 0 ]; then
+                        if [ "$get_attr" != [] ]; then # callout_get script has been invoked
+                            if [ "$get_attr" == [{}] ]; then
+                                get_attr=[]
+                            fi
+
+                            json_tmp=$(echo "$json_tmp" | jq --argjson att "{\"attrs\":$get_attr}" \
+                                    '(.matrix | .[] | .[] | .) += $att')
+                        fi
+                    fi
+                fi
 
                 if [ -f "$persist_base/$p/$u" ]; then
                     read_config "$persist_base/$p/$u"


### PR DESCRIPTION
This patch series introduces a method for mdevctl to invoke external scripts for device events and to broadcast notifications. See updates to README for more information.

Addresses #20 and #27.