### PR TITLE
[safe-refactor] refactor code to allow for easier unit testing

### DIFF
--- a/mdevctl
+++ b/mdevctl
@@ -314,6 +314,376 @@ unique_uuid() {
     echo "$uuid"
 }
 
+
+define_device() {
+    if [ -n "$jsonfile" ]; then
+        if [ ! -r "$jsonfile" ]; then
+            echo "Unable to read file $jsonfile" >&2
+            exit 1
+        fi
+        if [ -n "$type" ]; then
+            echo "Device type cannot be specified separately from $jsonfile" >&2
+            exit 1
+        fi
+        if [ -z "$parent" ]; then
+            echo "Parent device required to define device via $jsonfile" >&2
+        fi
+        if [ -z "$uuid" ]; then
+            uuid=$(unique_uuid)
+            print_uuid="echo $uuid"
+        fi
+        if [ -e "$persist_base/$parent/$uuid" ]; then
+            echo "Cowardly refusing to overwrite existing config for $parent/$uuid" >&2
+            exit 1
+        fi
+        set -o errexit
+        read_config "$jsonfile"
+        if [ $? -ne 0 ]; then
+            echo "Error reading $jsonfile" >&2
+            exit 1
+        fi
+        write_config "$persist_base/$parent/$uuid"
+        if [ $? -ne 0 ]; then
+            exit 1
+        fi
+        $print_uuid
+        exit 0
+    fi
+    if [ -n "$uuid" ]; then
+        if [ -z "$parent" ]; then
+            if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
+                usage
+            fi
+            parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
+            type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
+        fi
+        if [ -e "$persist_base/$parent/$uuid" ]; then
+            echo "Device $uuid on $parent already defined, try modify?" >&2
+            exit 1
+        fi
+    else
+        uuid=$(unique_uuid)
+        print_uuid="echo $uuid"
+    fi
+    if [ -z "$parent" ]; then
+        usage
+    fi
+    if [ -z "$type" ]; then
+        usage
+    fi
+    if [ -n "$auto" ]; then
+        start="auto"
+    else
+        start="manual"
+    fi
+    set -o errexit
+    mkdir -p "$persist_base/$parent"
+    set_config_key mdev_type "$type"
+    set_config_key start "$start"
+    write_config "$persist_base/$parent/$uuid"
+    if [ $? -eq 0 ]; then
+        $print_uuid
+    fi
+}
+
+undefine_device() {
+    if [ -z "$uuid" ]; then
+        usage
+    fi
+    set -o errexit
+    if [ -n "$parent" ]; then
+        rm -f "$persist_base/$parent/$uuid"
+    else
+        find "$persist_base" -name "$uuid" -type f | xargs rm -f
+    fi
+}
+
+modify_device() {
+    if [ -z "$uuid" ]; then
+        usage
+    fi
+    if [ -n "$auto" ] && [ -n "$manual" ]; then
+        echo "Options --auto and --manual are mutually exclusive" >&2
+        exit 1
+    fi
+    set -o errexit
+    file=$(config_file "$uuid" "$parent")
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+    read_config "$file"
+    if [ $? -ne 0 ]; then
+        echo "Config file $file invalid" >&2
+        exit 1
+    fi
+    if [ -n "$type" ]; then
+        set_config_key mdev_type "$type"
+    fi
+    if [ -n "$auto" ]; then
+        set_config_key start auto
+    fi
+    if [ -n "$manual" ]; then
+        set_config_key start manual
+    fi
+    if [ -n "$addattr" ] && [ -n "$delattr" ]; then
+        usage
+    fi
+    if [ -n "$addattr" ]; then
+        if [ -n "$index" ]; then
+            if [ "$index" -eq "$index" ] 2>/dev/null; then
+                :
+            else
+                echo "Provided index is not a number" >&2
+                usage
+            fi
+        fi
+        if [ -z "$value" ]; then
+            echo "No attribute value provided" >&2
+            usage
+        fi
+        add_attr_index "$addattr" "$value" "$index"
+    fi
+    if [ -n "$delattr" ]; then
+        if [ -n "$index" ]; then
+            if [ "$index" -eq "$index" ] 2>/dev/null; then
+                :
+            else
+                echo "Provided index is not a number" >&2
+                usage
+            fi
+        fi
+        del_attr_index "$index"
+    fi
+    write_config "$file"
+}
+
+start_device() {
+    set -o errexit
+    if [ -n "$jsonfile" ]; then
+        if [ ! -r "$jsonfile" ]; then
+            echo "Unable to read file $jsonfile" >&2
+            exit 1
+        fi
+        if [ -n "$type" ]; then
+            echo "Device type cannot be specified separately from $jsonfile" >&2
+            exit 1
+        fi
+        if [ -z "$parent" ]; then
+            echo "Parent device required to start device via $jsonfile" >&2
+            exit 1
+        fi
+        if [ -z "$uuid" ]; then
+            uuid=$(unique_uuid)
+            print_uuid="echo $uuid"
+        fi
+        read_config "$jsonfile"
+        if [ $? -ne 0 ]; then
+            echo "Error reading $jsonfile" >&2
+            exit 1
+        fi
+        type="$(get_config_key mdev_type)"
+        start_mdev "$uuid" "$parent" "$type" "$print_uuid"
+        exit $?
+    fi
+    # We don't implement a placement policy
+    if [ -n "$type" ] && [ -z "$parent" ]; then
+        usage
+    fi
+    # The device is not fully specified without TYPE, we must find
+    # a config file, with optional PARENT for disambiguation
+    if [ -z "$type" ] && [ -n "$uuid" ]; then
+        count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
+        if [ "$count" -eq 0 ]; then
+            echo "Config for $uuid does not exist, define it first?" >&2
+            exit 1
+        elif [ "$count" -gt 1 ]; then
+            if [ -z "$parent" ] || [ ! -e "$persist_base/$parent/$uuid" ]; then
+                echo "Multiple configs found for $uuid, specify a parent" >&2
+                exit 1
+            fi
+            file="$persist_base/$parent/$uuid"
+        else
+            file=$(find "$persist_base" -name "$uuid" -type f)
+            if [ -n "$parent" ]; then
+                cur_parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
+                if [ "$cur_parent" != "$parent" ]; then
+                    echo "Config for $parent/$uuid does not exist, define it first?" >&2
+                    exit 1
+                fi
+            fi
+        fi
+        read_config "$file"
+        if [ $? -ne 0 ]; then
+            echo "Config file $file invalid" >&2
+            exit 1
+        fi
+        if [ -z "$parent" ]; then
+            parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
+        fi
+        type="$(get_config_key mdev_type)"
+    fi
+    if [ -z "$uuid" ]; then
+        # Device must be full specified otherwise for generated UUID
+        if [ -z "$parent" ] || [ -z "$type" ]; then
+            echo "Device is insufficiently specified" >&2
+            usage
+        fi
+        uuid=$(unique_uuid)
+        print_uuid="echo $uuid"
+    fi
+    start_mdev "$uuid" "$parent" "$type" "$print_uuid"
+    exit $?
+}
+
+stop_device() {
+    if [ -z "$uuid" ]; then
+        usage
+    fi
+    set -o errexit
+    remove_mdev "$uuid"
+}
+
+list_device() {
+    json="[]"
+    txt=""
+    if [ -n "$defined" ]; then
+        for dir in $(find "$persist_base/" -maxdepth 1 -mindepth 1 -type d | sort); do
+            p=$(basename "$dir")
+            if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
+                continue
+            fi
+            for mdev in $(find "$dir/" -maxdepth 1 -mindepth 1 -type f); do
+                u=$(basename "$mdev")
+                if [ -n "$uuid" ] && [ "$uuid" != "$u" ]; then
+                    continue
+                fi
+                read_config "$mdev"
+                if [ $? -ne 0 ]; then
+                    continue
+                fi
+                type="$(get_config_key mdev_type)"
+                start="$(get_config_key start)"
+                txt+="$u $p $type $start"
+                if [ -L "$mdev_base/$u" ]; then
+                    cur_parent=$(basename $(realpath "$mdev_base/$u" | sed -s "s/\/$u//"))
+                    if [ "$cur_parent" == "$p" ]; then
+                        cur_type=$(basename $(realpath "$mdev_base/$u/mdev_type"))
+                        if [ "$cur_type" == "$type" ]; then
+                            txt+=" (active)"
+                        fi
+                    fi
+                fi
+                json_tmp="{\"$p\":[{\"$u\":{"\"mdev_type\":\"$type\"",\"start\":\"$start\""
+                txt+="\n"
+                if [ -n "$verbose" ] || [ -n "$dumpjson" ]; then
+                    count=$(( $(get_attr_length) - 1 ))
+                    if [ $count -ge 0 ]; then
+                        json_tmp+=",\"attrs\":$(get_attrs_raw)"
+                        txt+="  Attrs:\n"
+                        for i in $(seq 0 "$count"); do
+                            txt+="    @{$i}: $(get_attr_index_raw $i)\n"
+                        done
+                    fi
+                fi
+                json_tmp+="}}]}"
+                json=$(echo "$json" | jq -c -M --argjson obj "$json_tmp" '. + [$obj]')
+            done
+        done
+    else
+        if [ ! -d "$mdev_base" ]; then
+            exit 0
+        fi
+        for mdev in $(find "$mdev_base/" -maxdepth 1 -mindepth 1 -type l); do
+            u=$(basename "$mdev")
+            if [ -n "$uuid" ] && [ "$uuid" != "$u" ]; then
+                continue
+            fi
+            p=$(basename $(realpath "$mdev_base/$u" | sed -s "s/\/$u//"))
+            if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
+                continue
+            fi
+            type=$(basename $(realpath "$mdev/mdev_type"))
+            json_tmp="{\"$p\":[{\"$u\":{\"mdev_type\":\"$type\"}}]}"
+            txt+="$u $p $type"
+            if [ -f "$persist_base/$p/$u" ]; then
+                read_config "$persist_base/$p/$u"
+                if [ $? -eq 0 ] && [ "$(get_config_key mdev_type)" == "$type" ]; then
+                    txt+=" (defined)"
+                fi
+            fi
+            txt+="\n"
+            json=$(echo "$json" | jq -c -M --argjson obj "$json_tmp" '. + [$obj]')
+        done
+    fi
+    if [ -n "$dumpjson" ]; then
+        if [ $(echo "$json" | jq 'length') -gt 0 ]; then
+            # https://stackoverflow.com/a/43337323/4775714
+            json=$(echo "$json" | jq -c -M '[reduce .[] as $o ({}; reduce ($o|keys)[] as $key (.; .[$key] += $o[$key] ))]')
+        fi
+        # If specified to a single device, output such that it can be
+        # piped into a config file, else print entire hierarchy
+        if [ -n "$uuid" ] && [ $(echo "$json" | jq -M 'length') -eq 1 ] &&
+           [ $(echo "$json" | jq -M '.[] | length') -eq 1 ] &&
+           [ $(echo "$json" | jq -M '.[] | .[] | length') -eq 1 ]; then
+            key=$(echo "$json" | jq -r -M '.[] | .[] | .[] | keys | .[]')
+            key=$(jsonify $key)
+            echo "$json" | jq -M --argjson key "$key" '.[] | .[] | .[] | .[$key]'
+        else
+            echo "$json" | jq -M '.'
+        fi
+    else
+        echo -en "$txt"
+    fi
+}
+
+list_types() {
+    if [ ! -d "$parent_base" ]; then
+        if [ -n "$dumpjson" ]; then
+            echo "[]" | jq -M '.'
+        fi
+        exit 0
+    fi
+    json="[]"
+    txt=""
+    for dir in $(find "$parent_base/" -maxdepth 1 -mindepth 1 -type l | sort); do
+        p=$(basename "$dir")
+        if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
+            continue
+        fi
+        txt+="$p\n"
+        for parent_type in $(find "$dir/mdev_supported_types/" -maxdepth 1 -mindepth 1 -type d | sort); do
+            type=$(basename "$parent_type")
+            txt+="  $type\n"
+            avail=$(cat "$parent_type/available_instances")
+            txt+="    Available instances: $avail\n"
+            api=$(cat "$parent_type/device_api")
+            txt+="    Device API: $api\n"
+            json_tmp="{\"$p\":[{\"$type\":{\"available_instances\":$avail,\"device_api\":\"$api\""
+            if [ -e "$parent_type/name" ]; then
+                name=$(cat "$parent_type/name")
+                json_tmp+=",\"name\":\"$name\""
+                txt+="    Name: $name\n"
+            fi
+            if [ -e "$parent_type/description" ]; then
+                descr=$(cat "$parent_type/description" | sed -e ':a;N;$!ba;s/\n/, /g')
+                json_tmp+=",\"description\":\"$descr\""
+                txt+="    Description: $descr\n"
+            fi
+            json_tmp+="}}]}"
+            json=$(echo "$json" | jq -c -M --argjson obj "$json_tmp" '. + [$obj]')
+        done
+    done
+    if [ -n "$dumpjson" ]; then
+        if [ $(echo "$json" | jq 'length') -gt 0 ]; then
+            # https://stackoverflow.com/a/43337323/4775714
+            json=$(echo "$json" | jq -c -M '[reduce .[] as $o ({}; reduce ($o|keys)[] as $key (.; .[$key] += $o[$key] ))]')
+        fi
+        echo "$json" | jq -M '.'
+    else
+        echo -en "$txt"
+    fi
+}
+
 usage() {
     cat >&2 <<EOF
 Usage: $(basename $0) {COMMAND} [options...]
@@ -391,627 +761,217 @@ EOF
     exit 1
 }
 
-if [ $# -lt 1 ]; then
-    usage
-fi
+parse_args() {
+    if [ $# -lt 1 ]; then
+        usage
+    fi
 
-case ${1} in
-    #
-    # Internal commands, these are expected to be called from other scripts
-    # and therefore do not offer the convenience of getopt processing
-    # (they typically take one arg after the command) and are not listed in
-    # the usage text
-    #
-    start-parent-mdevs)
-        if [ $# -ne 2 ]; then
-            echo "Usage: $0 $1 <parent device>" >&2
-            exit 1
-        fi
-
-        parent="$2"
-        if [ ! -d "$persist_base/$parent" ]; then
-            # Nothing to do
-            exit 0
-        fi
-
-        for file in $(find "$persist_base/$parent/" -maxdepth 1 -mindepth 1 -type f); do
-            uuid=$(basename "$file")
-            if [ -n "$(valid_uuid $uuid)" ]; then
-                read_config "$file"
-                if [ $? -ne 0 ]; then
-                    continue
-                fi
-
-                if [ "$(get_config_key start)" == "auto" ]; then
-                    start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
-                    if [ $? -ne 0 ]; then
-                        echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
-                        # continue...
-                    fi
-                fi
+    case ${1} in
+        #
+        # Internal commands, these are expected to be called from other scripts
+        # and therefore do not offer the convenience of getopt processing
+        # (they typically take one arg after the command) and are not listed in
+        # the usage text
+        #
+        start-parent-mdevs)
+            if [ $# -ne 2 ]; then
+                echo "Usage: $0 $1 <parent device>" >&2
+                exit 1
             fi
-        done
-        exit 0
-        ;;
-    #
-    # User commands
-    #
-    --help|-h|-?)
-        usage
-        ;;
-    version)
-        cmd="$1"
-        OPTIONS=""
-        LONGOPTS=""
-        shift
-	;;
-    define)
-        cmd="$1"
-        OPTIONS="u:p:t:a"
-        LONGOPTS="uuid:,parent:,type:,auto,jsonfile:"
-        shift
-        ;;
-    undefine)
-        cmd="$1"
-        OPTIONS="u:p:"
-        LONGOPTS="uuid:,parent:"
-        shift
-        ;;
-    modify)
-        cmd="$1"
-        OPTIONS="u:p:t:ami:"
-        LONGOPTS="uuid:,parent:,type:,auto,manual,addattr:,delattr,index:,value:"
-        shift
-        ;;
-    start)
-        cmd="$1"
-        OPTIONS="u:p:t:"
-        LONGOPTS="uuid:,parent:,type:,jsonfile:"
-        shift
-        ;;
-    stop)
-        cmd="$1"
-        OPTIONS="u:"
-        LONGOPTS="uuid:"
-        shift
-        ;;
-    list)
-        cmd="$1"
-        OPTIONS="du:p:v"
-        LONGOPTS="defined,uuid:,dumpjson,parent:,verbose"
-        shift
-        ;;
-    types)
-        cmd="$1"
-        OPTIONS="p:"
-        LONGOPTS="parent:,dumpjson"
-        shift
-        ;;
-    *)
-        echo "Unknown command $1" >&2
-        usage
-        ;;
-esac
 
-PARSED=$(getopt --options="$OPTIONS" --longoptions="$LONGOPTS" --name "$(basename $0)" -- "$@")
-if [ $? -ne 0 ]; then
-    exit 1
-fi
-
-eval set -- "$PARSED"
-
-while true; do
-    case "$1" in
-        -u|--uuid)
-            uuid="$2"
-            shift 2
-            ;;
-        -p|--parent)
             parent="$2"
-            shift 2
-            ;;
-        -t|--type)
-            type="$2"
-            shift 2
-            ;;
-        --jsonfile)
-            jsonfile="$2"
-            shift 2
-            ;;
-        --addattr)
-            addattr="$2"
-            shift 2
-            ;;
-        -i|--index)
-            index="$2"
-            shift 2
-            ;;
-        --value)
-            value="$2"
-            shift 2
-            ;;
-        --delattr)
-            delattr=y
-            shift 1
-            ;;
-        --dumpjson)
-            dumpjson=y
-            shift
-            ;;
-        -a|--auto)
-            auto=y
-            shift 1
-            ;;
-        -m|--manual)
-            manual=y
-            shift 1
-            ;;
-        -d|--defined)
-            defined=y
-            shift 1
-            ;;
-        -v|--verbose)
-            verbose=y
-            shift 1
-            ;;
-        --)
-            shift
-            break
-            ;;
-        *)
-            echo "Programming error"
-            exit 1
-            ;;
-    esac
-done
-
-if [ $# -ne 0 ]; then
-    echo "$(basename $0): Unknown options: $@"
-    exit 1
-fi
-
-case "$cmd" in
-    version)
-        echo $version
-        ;;
-    define)
-        if [ -n "$jsonfile" ]; then
-            if [ ! -r "$jsonfile" ]; then
-                echo "Unable to read file $jsonfile" >&2
-                exit 1
-            fi
-
-            if [ -n "$type" ]; then
-                echo "Device type cannot be specified separately from $jsonfile" >&2
-                exit 1
-            fi
-
-            if [ -z "$parent" ]; then
-                echo "Parent device required to define device via $jsonfile" >&2
-                exit 1
-            fi
-
-            if [ -z "$uuid" ]; then
-                uuid=$(unique_uuid)
-                print_uuid="echo $uuid"
-            fi
-
-            if [ -e "$persist_base/$parent/$uuid" ]; then
-                echo "Cowardly refusing to overwrite existing config for $parent/$uuid" >&2
-                exit 1
-            fi
-
-            set -o errexit
-
-            read_config "$jsonfile"
-            if [ $? -ne 0 ]; then
-                echo "Error reading $jsonfile" >&2
-                exit 1
-            fi
-
-            write_config "$persist_base/$parent/$uuid"
-            if [ $? -ne 0 ]; then
-                exit 1
-            fi
-
-            $print_uuid
-            exit 0
-        fi
-
-        if [ -n "$uuid" ]; then
-            if [ -z "$parent" ]; then
-                if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
-                    usage
-                fi
-
-                parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
-                type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
-            fi
-
-            if [ -e "$persist_base/$parent/$uuid" ]; then
-                echo "Device $uuid on $parent already defined, try modify?" >&2
-                exit 1
-            fi
-        else
-            uuid=$(unique_uuid)
-            print_uuid="echo $uuid"
-        fi
-
-        if [ -z "$parent" ]; then
-            usage
-        fi
-
-        if [ -z "$type" ]; then
-            usage
-        fi
-
-        if [ -n "$auto" ]; then
-            start="auto"
-        else
-            start="manual"
-        fi
-
-        set -o errexit
-
-        mkdir -p "$persist_base/$parent"
-        set_config_key mdev_type "$type"
-        set_config_key start "$start"
-        write_config "$persist_base/$parent/$uuid"
-        if [ $? -eq 0 ]; then
-            $print_uuid
-        fi
-        ;;
-    undefine)
-        if [ -z "$uuid" ]; then
-            usage
-        fi
-
-        set -o errexit
-
-        if [ -n "$parent" ]; then
-            rm -f "$persist_base/$parent/$uuid"
-        else
-            find "$persist_base" -name "$uuid" -type f | xargs rm -f
-        fi
-        ;;
-    modify)
-        if [ -z "$uuid" ]; then
-            usage
-        fi
-
-        if [ -n "$auto" ] && [ -n "$manual" ]; then
-            echo "Options --auto and --manual are mutually exclusive" >&2
-            exit 1
-        fi
-
-        set -o errexit
-
-        file=$(config_file "$uuid" "$parent")
-        if [ $? -ne 0 ]; then
-            exit 1
-        fi
-
-        read_config "$file"
-        if [ $? -ne 0 ]; then
-            echo "Config file $file invalid" >&2
-            exit 1
-        fi
-
-        if [ -n "$type" ]; then
-            set_config_key mdev_type "$type"
-        fi
-
-        if [ -n "$auto" ]; then
-            set_config_key start auto
-        fi
-
-        if [ -n "$manual" ]; then
-            set_config_key start manual
-        fi
-
-        if [ -n "$addattr" ] && [ -n "$delattr" ]; then
-            usage
-        fi
-
-        if [ -n "$addattr" ]; then
-            if [ -n "$index" ]; then
-                if [ "$index" -eq "$index" ] 2>/dev/null; then
-                    :
-                else
-                    echo "Provided index is not a number" >&2
-                    usage
-                fi
-            fi
-
-            if [ -z "$value" ]; then
-                echo "No attribute value provided" >&2
-                usage
-            fi
-
-            add_attr_index "$addattr" "$value" "$index"
-        fi
-
-        if [ -n "$delattr" ]; then
-            if [ -n "$index" ]; then
-                if [ "$index" -eq "$index" ] 2>/dev/null; then
-                    :
-                else
-                    echo "Provided index is not a number" >&2
-                    usage
-                fi
-            fi
-
-            del_attr_index "$index"
-        fi
-
-        write_config "$file"
-        ;;
-    start)
-        set -o errexit
-
-        if [ -n "$jsonfile" ]; then
-            if [ ! -r "$jsonfile" ]; then
-                echo "Unable to read file $jsonfile" >&2
-                exit 1
-            fi
-
-            if [ -n "$type" ]; then
-                echo "Device type cannot be specified separately from $jsonfile" >&2
-                exit 1
-            fi
-
-            if [ -z "$parent" ]; then
-                echo "Parent device required to start device via $jsonfile" >&2
-                exit 1
-            fi
-
-            if [ -z "$uuid" ]; then
-                uuid=$(unique_uuid)
-                print_uuid="echo $uuid"
-            fi
-
-            read_config "$jsonfile"
-            if [ $? -ne 0 ]; then
-                echo "Error reading $jsonfile" >&2
-                exit 1
-            fi
-
-            type="$(get_config_key mdev_type)"
-
-            start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-            exit $?
-        fi
-
-        # We don't implement a placement policy
-        if [ -n "$type" ] && [ -z "$parent" ]; then
-            usage
-        fi
-
-        # The device is not fully specified without TYPE, we must find
-        # a config file, with optional PARENT for disambiguation
-        if [ -z "$type" ] && [ -n "$uuid" ]; then
-            count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
-            if [ "$count" -eq 0 ]; then
-                echo "Config for $uuid does not exist, define it first?" >&2
-                exit 1
-            elif [ "$count" -gt 1 ]; then
-                if [ -z "$parent" ] || [ ! -e "$persist_base/$parent/$uuid" ]; then
-                    echo "Multiple configs found for $uuid, specify a parent" >&2
-                    exit 1
-                fi
-                file="$persist_base/$parent/$uuid"
-            else
-                file=$(find "$persist_base" -name "$uuid" -type f)
-                if [ -n "$parent" ]; then
-                    cur_parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
-                    if [ "$cur_parent" != "$parent" ]; then
-                        echo "Config for $parent/$uuid does not exist, define it first?" >&2
-                        exit 1
-                    fi
-                fi
-            fi
-
-            read_config "$file"
-            if [ $? -ne 0 ]; then
-                echo "Config file $file invalid" >&2
-                exit 1
-            fi
-
-            if [ -z "$parent" ]; then
-                parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
-            fi
-
-            type="$(get_config_key mdev_type)"
-        fi
-
-        if [ -z "$uuid" ]; then
-            # Device must be full specified otherwise for generated UUID
-            if [ -z "$parent" ] || [ -z "$type" ]; then
-                echo "Device is insufficiently specified" >&2
-                usage
-            fi
-            uuid=$(unique_uuid)
-            print_uuid="echo $uuid"
-        fi
-
-        start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-        exit $?
-        ;;
-    stop)
-        if [ -z "$uuid" ]; then
-            usage
-        fi
-
-        set -o errexit
-
-        remove_mdev "$uuid"
-        ;;
-    list)
-        json="[]"
-        txt=""
-
-        if [ -n "$defined" ]; then
-            for dir in $(find "$persist_base/" -maxdepth 1 -mindepth 1 -type d | sort); do
-                p=$(basename "$dir")
-                if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
-                    continue
-                fi
-
-                for mdev in $(find "$dir/" -maxdepth 1 -mindepth 1 -type f); do
-                    u=$(basename "$mdev")
-                    if [ -n "$uuid" ] && [ "$uuid" != "$u" ]; then
-                        continue
-                    fi
-
-                    read_config "$mdev"
-                    if [ $? -ne 0 ]; then
-                        continue
-                    fi
-
-                    type="$(get_config_key mdev_type)"
-                    start="$(get_config_key start)"
-
-                    txt+="$u $p $type $start"
-
-                    if [ -L "$mdev_base/$u" ]; then
-                        cur_parent=$(basename $(realpath "$mdev_base/$u" | sed -s "s/\/$u//"))
-                        if [ "$cur_parent" == "$p" ]; then
-                            cur_type=$(basename $(realpath "$mdev_base/$u/mdev_type"))
-                            if [ "$cur_type" == "$type" ]; then
-                                txt+=" (active)"
-                            fi
-                        fi
-                    fi
-
-                    json_tmp="{\"$p\":[{\"$u\":{"\"mdev_type\":\"$type\"",\"start\":\"$start\""
-                    txt+="\n"
-
-                    if [ -n "$verbose" ] || [ -n "$dumpjson" ]; then
-                        count=$(( $(get_attr_length) - 1 ))
-                        if [ $count -ge 0 ]; then
-                            json_tmp+=",\"attrs\":$(get_attrs_raw)"
-                            txt+="  Attrs:\n"
-                            for i in $(seq 0 "$count"); do
-                                txt+="    @{$i}: $(get_attr_index_raw $i)\n"
-                            done
-                        fi
-                    fi
-                    json_tmp+="}}]}"
-                    json=$(echo "$json" | jq -c -M --argjson obj "$json_tmp" '. + [$obj]')
-                done
-            done
-        else
-            if [ ! -d "$mdev_base" ]; then
+            if [ ! -d "$persist_base/$parent" ]; then
+                # Nothing to do
                 exit 0
             fi
 
-            for mdev in $(find "$mdev_base/" -maxdepth 1 -mindepth 1 -type l); do
-                u=$(basename "$mdev")
-                if [ -n "$uuid" ] && [ "$uuid" != "$u" ]; then
-                    continue
-                fi
+            for file in $(find "$persist_base/$parent/" -maxdepth 1 -mindepth 1 -type f); do
+                uuid=$(basename "$file")
+                if [ -n "$(valid_uuid $uuid)" ]; then
+                    read_config "$file"
+                    if [ $? -ne 0 ]; then
+                        continue
+                    fi
 
-                p=$(basename $(realpath "$mdev_base/$u" | sed -s "s/\/$u//"))
-                if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
-                    continue
-                fi
-
-                type=$(basename $(realpath "$mdev/mdev_type"))
-
-                json_tmp="{\"$p\":[{\"$u\":{\"mdev_type\":\"$type\"}}]}"
-                txt+="$u $p $type"
-
-                if [ -f "$persist_base/$p/$u" ]; then
-                    read_config "$persist_base/$p/$u"
-                    if [ $? -eq 0 ] && [ "$(get_config_key mdev_type)" == "$type" ]; then
-                        txt+=" (defined)"
+                    if [ "$(get_config_key start)" == "auto" ]; then
+                        start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
+                        if [ $? -ne 0 ]; then
+                            echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
+                            # continue...
+                        fi
                     fi
                 fi
-
-                txt+="\n"
-                json=$(echo "$json" | jq -c -M --argjson obj "$json_tmp" '. + [$obj]')
-
             done
-        fi
-
-        if [ -n "$dumpjson" ]; then
-            if [ $(echo "$json" | jq 'length') -gt 0 ]; then
-                # https://stackoverflow.com/a/43337323/4775714
-                json=$(echo "$json" | jq -c -M '[reduce .[] as $o ({}; reduce ($o|keys)[] as $key (.; .[$key] += $o[$key] ))]')
-            fi
-
-            # If specified to a single device, output such that it can be
-            # piped into a config file, else print entire hierarchy
-            if [ -n "$uuid" ] && [ $(echo "$json" | jq -M 'length') -eq 1 ] &&
-               [ $(echo "$json" | jq -M '.[] | length') -eq 1 ] &&
-               [ $(echo "$json" | jq -M '.[] | .[] | length') -eq 1 ]; then
-                key=$(echo "$json" | jq -r -M '.[] | .[] | .[] | keys | .[]')
-                key=$(jsonify $key)
-                echo "$json" | jq -M --argjson key "$key" '.[] | .[] | .[] | .[$key]'
-            else
-                echo "$json" | jq -M '.'
-            fi
-        else
-            echo -en "$txt"
-        fi
-        ;;
-    types)
-        if [ ! -d "$parent_base" ]; then
-            if [ -n "$dumpjson" ]; then
-                echo "[]" | jq -M '.'
-            fi
             exit 0
-        fi
+            ;;
+        #
+        # User commands
+        #
+        --help|-h|-?)
+            usage
+            ;;
+        version)
+            cmd="$1"
+            OPTIONS=""
+            LONGOPTS=""
+            shift
+            ;;
+        define)
+            cmd="$1"
+            OPTIONS="u:p:t:a"
+            LONGOPTS="uuid:,parent:,type:,auto,jsonfile:"
+            shift
+            ;;
+        undefine)
+            cmd="$1"
+            OPTIONS="u:p:"
+            LONGOPTS="uuid:,parent:"
+            shift
+            ;;
+        modify)
+            cmd="$1"
+            OPTIONS="u:p:t:ami:"
+            LONGOPTS="uuid:,parent:,type:,auto,manual,addattr:,delattr,index:,value:"
+            shift
+            ;;
+        start)
+            cmd="$1"
+            OPTIONS="u:p:t:"
+            LONGOPTS="uuid:,parent:,type:,jsonfile:"
+            shift
+            ;;
+        stop)
+            cmd="$1"
+            OPTIONS="u:"
+            LONGOPTS="uuid:"
+            shift
+            ;;
+        list)
+            cmd="$1"
+            OPTIONS="du:p:v"
+            LONGOPTS="defined,uuid:,dumpjson,parent:,verbose"
+            shift
+            ;;
+        types)
+            cmd="$1"
+            OPTIONS="p:"
+            LONGOPTS="parent:,dumpjson"
+            shift
+            ;;
+        *)
+            echo "Unknown command $1" >&2
+            usage
+            ;;
+    esac
 
-        json="[]"
-        txt=""
+    PARSED=$(getopt --options="$OPTIONS" --longoptions="$LONGOPTS" --name "$(basename $0)" -- "$@")
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
 
-        for dir in $(find "$parent_base/" -maxdepth 1 -mindepth 1 -type l | sort); do
-            p=$(basename "$dir")
-            if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
-                continue
-            fi
+    eval set -- "$PARSED"
 
-            txt+="$p\n"
+    while true; do
+        case "$1" in
+            -u|--uuid)
+                uuid="$2"
+                shift 2
+                ;;
+            -p|--parent)
+                parent="$2"
+                shift 2
+                ;;
+            -t|--type)
+                type="$2"
+                shift 2
+                ;;
+            --jsonfile)
+                jsonfile="$2"
+                shift 2
+                ;;
+            --addattr)
+                addattr="$2"
+                shift 2
+                ;;
+            -i|--index)
+                index="$2"
+                shift 2
+                ;;
+            --value)
+                value="$2"
+                shift 2
+                ;;
+            --delattr)
+                delattr=y
+                shift 1
+                ;;
+            --dumpjson)
+                dumpjson=y
+                shift
+                ;;
+            -a|--auto)
+                auto=y
+                shift 1
+                ;;
+            -m|--manual)
+                manual=y
+                shift 1
+                ;;
+            -d|--defined)
+                defined=y
+                shift 1
+                ;;
+            -v|--verbose)
+                verbose=y
+                shift 1
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                echo "Programming error"
+                exit 1
+                ;;
+        esac
+    done
 
-            for parent_type in $(find "$dir/mdev_supported_types/" -maxdepth 1 -mindepth 1 -type d | sort); do
-                type=$(basename "$parent_type")
-                txt+="  $type\n"
+    if [ $# -ne 0 ]; then
+        echo "$(basename $0): Unknown options: $@"
+        exit 1
+    fi
+}
 
-                avail=$(cat "$parent_type/available_instances")
-                txt+="    Available instances: $avail\n"
+run_command() {
+    case "$cmd" in
+        version)
+            echo $version
+            ;;
+        define)
+            define_device
+            ;;
+        undefine)
+            undefine_device
+            ;;
+        modify)
+            modify_device
+            ;;
+        start)
+            start_device
+            ;;
+        stop)
+            stop_device
+            ;;
+        list)
+            list_devices
+            ;;
+        types)
+            list_types
+            ;;
+    esac
+}
 
-                api=$(cat "$parent_type/device_api")
-                txt+="    Device API: $api\n"
-
-                json_tmp="{\"$p\":[{\"$type\":{\"available_instances\":$avail,\"device_api\":\"$api\""
-
-                if [ -e "$parent_type/name" ]; then
-                    name=$(cat "$parent_type/name")
-                    json_tmp+=",\"name\":\"$name\""
-                    txt+="    Name: $name\n"
-                fi
-
-                if [ -e "$parent_type/description" ]; then
-                    descr=$(cat "$parent_type/description" | sed -e ':a;N;$!ba;s/\n/, /g')
-                    json_tmp+=",\"description\":\"$descr\""
-                    txt+="    Description: $descr\n"
-                fi
-
-                json_tmp+="}}]}"
-                json=$(echo "$json" | jq -c -M --argjson obj "$json_tmp" '. + [$obj]')
-            done
-        done
-
-        if [ -n "$dumpjson" ]; then
-            if [ $(echo "$json" | jq 'length') -gt 0 ]; then
-                # https://stackoverflow.com/a/43337323/4775714
-                json=$(echo "$json" | jq -c -M '[reduce .[] as $o ({}; reduce ($o|keys)[] as $key (.; .[$key] += $o[$key] ))]')
-            fi
-
-            echo "$json" | jq -M '.'
-        else
-            echo -en "$txt"
-        fi
-        ;;
-esac
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    parse_args "${@}"
+    run_command
+fi


### PR DESCRIPTION
Existing behavior is not changed.

As can be seen, there is no change in logic, only parts of the code have
been moved into smaller functions in order to allow for unit testing them
more easily.

As unit tests will want to source the script file in order to test the
functions in isolation, a switch has been added to avoid script execution
when the script is sourced.

1. Define top-level functions
 - `parse_args` to hold the argument parsing logic. After this function
   is run, global arguments have been assigned to script global variables
   to be used in other functions.
 - `run_command` contains the command selection and delegation to handling
   functions.
2. Define handling functions
 - Each case' commands have been moved from `run_command` to top-level
   functions. This way a unit test can call for example only the function
   under test.
 - A unit test could look like:
   ```bash
    #!/bin/bash
    source mdevctl
    source setup # some logic to use local $parent_base and $mdev_base
                 # for testing instead of the real ones
    res=0
    parent=some_parent
    type=some_type
    result=$(define_device)
    if ! [[ "$?" -eq "0" ]] || [[ -z "$result" ]]; then
        echo "Failed to define device."
        res=1
    fi
    exit res
   ```
3. Add switch to avoid execution during sourcing.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>