### PR TITLE
[v2] Invoking External Scripts for Device Events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREFIX=/usr
 UDEVDIR=$(shell pkg-config --variable=udevdir udev)
 SBINDIR=$(PREFIX)/sbin
 CONFDIR=/etc/mdevctl.d
+CALLOUT_CMD_DIR=$(CONFDIR)/callouts/scripts.d
+CALLOUT_NOTIFIER_DIR=$(CONFDIR)/notification/notifiers.d
 MANDIR=$(PREFIX)/share/man
 NAME=mdevctl
 MDEVCTL_VER=$(shell ./mdevctl version)
@@ -44,6 +46,8 @@ install:
 	mkdir -p $(DESTDIR)$(MANDIR)/man8
 	install -m 644 mdevctl.8 $(DESTDIR)$(MANDIR)/man8/
 	ln -sf mdevctl.8  $(DESTDIR)$(MANDIR)/man8/lsmdev.8
+	mkdir -p $(DESTDIR)$(CALLOUT_CMD_DIR)
+	mkdir -p $(DESTDIR)$(CALLOUT_NOTIFIER_DIR)
 
 clean:
 	rm -f mdevctl.spec *.src.rpm noarch/*.rpm *.tar.gz

--- a/README.md
+++ b/README.md
@@ -267,4 +267,28 @@ e2e73122-cc39-40ee-89eb-b0a47d334cae matrix vfio_ap-passthrough manual
     @{2}: {"assign_domain":"0xff"}
 ```
 
+# Invoking External Scripts for Device Events
+
+Certain mediated devices may require additional operations or functionality,
+such as configuration checking or event reporting, before or after mdevctl
+executes a command. In order to remain device-type agnostic, mdevctl will
+"call-out" to external scripts to handle the extraneous work. These scripts
+are associated with a specific device type to perform any operations or
+additional functionality not handled within mdevctl. Additionally, external
+programs may wish to receive notifications of any action performed by mdevctl
+to e.g. respond to any device changes or keep device management in parallel.
+
+A call-out script is invoked at various points during an mdevctl command
+process and are categorized by an "event" paired with an "action", along
+with information regarding the mediated device. Two main event types are
+"pre" and "post", which are invoked before and after primary command
+execution respectively. The same call-out script is invoked for both events.
+
+A "notify" event script is invoked to report the status of mdevctl's
+command results. This may be used to signal external programs of changes
+made to a mediated device, or simply to assist with debugging efforts.
+
+A "get" event script is invoked for the define and list commands to acquire
+device attributes from sysfs.
+
 See `mdevctl --help` or the manpage for more information.

--- a/logger.sh
+++ b/logger.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -e event -a action -s state -u uuid -p parent
+shift
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+if [[ "$event" == "notify" ]]; then
+	echo "Event: $event, Action: $action, State: $state, UUID: $uuid, Parent: $parent, JSON:" | logger -t "mdevctl_logger"
+	echo "$json" | logger -t "mdevctl_logger"
+fi

--- a/mdevctl
+++ b/mdevctl
@@ -823,12 +823,48 @@ case "$cmd" in
             usage
         fi
 
-        set -o errexit
-
         if [ -n "$parent" ]; then
-            rm -f "$persist_base/$parent/$uuid"
+            read_config "$persist_base/$parent/$uuid"
+            type="$(get_config_key mdev_type)"
+
+            callout "pre" "$cmd" "$uuid" "$parent" "$type"
+            if [ $? -eq 0 ]; then
+                rm -f "$persist_base/$parent/$uuid"
+                if [ $? -eq 0 ]; then
+                    state="success"
+                else
+                    state="failure"
+                fi
+
+                callout "post" "$cmd" "$uuid" "$parent" "$type"
+            fi
+
+            callout_notify "$cmd" "$uuid" "$parent" "$type"
         else
-            find "$persist_base" -name "$uuid" -type f | xargs rm -f
+            undef_configs=$(find "$persist_base" -name "$uuid" -type f)
+
+            if [ -n "$undef_configs" ]; then
+                for p in $undef_configs; do
+                    parent=$(basename $(realpath "$p" | sed -s "s/\/$uuid//"))
+                    read_config "$persist_base/$parent/$uuid"
+                    type="$(get_config_key mdev_type)"
+
+                    callout "pre" "$cmd" "$uuid" "$parent" "$type"
+                    if [ $? -eq 0 ]; then
+                        rm -f "$persist_base/$parent/$uuid"
+                        if [ $? -eq 0 ]; then
+                            state="success"
+                        else
+                            state="failure"
+                        fi
+
+                        callout "post" "$cmd" "$uuid" "$parent" "$type"
+                    fi
+
+                    callout_notify "$cmd" "$uuid" "$parent" "$type"
+                    script=""
+                done
+            fi
         fi
 
         exit 0

--- a/mdevctl
+++ b/mdevctl
@@ -580,11 +580,22 @@ case ${1} in
                 fi
 
                 if [ "$(get_config_key start)" == "auto" ]; then
-                    start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
-                    if [ $? -ne 0 ]; then
-                        echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
-                        # continue...
+                    callout "pre" "start" "$uuid" "$parent" "$(get_config_key mdev_type)" 2>&1 | logger -t $(basename $0) -p err
+                    if [ $? -eq 0 ]; then
+                        start_mdev "$uuid" "$parent" "$(get_config_key mdev_type)"
+                        if [ $? -ne 0 ]; then
+                            echo "Failed to create mdev $uuid, type $(get_config_key mdev_type) on $parent" >&2
+                            # continue...
+
+                            state="failure"
+                        else
+                            state="success"
+                        fi
+
+                        callout "post" "start" "$uuid" "$parent" "$(get_config_key mdev_type)" 2>&1 | logger -t $(basename $0) -p err
                     fi
+
+                    callout_notify "start" "$uuid" "$parent" "$type" | logger -t $(basename $0) -p notice
                 fi
             fi
         done
@@ -978,9 +989,6 @@ case "$cmd" in
                 print_uuid="echo $uuid"
             fi
         fi
-
-        start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-        exit $?
         ;;
     stop)
         if [ -z "$uuid" ]; then
@@ -1174,6 +1182,9 @@ case "$cmd" in
         ;;
     modify)
         write_config "$file"
+        ;;
+    start)
+        start_mdev "$uuid" "$parent" "$type" "$print_uuid"
         ;;
     stop)
         remove_mdev "$uuid"

--- a/mdevctl
+++ b/mdevctl
@@ -616,7 +616,6 @@ case "$cmd" in
                     if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
                         usage
                     fi
-
                     parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
                     type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
                 fi
@@ -650,11 +649,6 @@ case "$cmd" in
             set_config_key mdev_type "$type"
             set_config_key start "$start"
         fi
-
-        write_config "$persist_base/$parent/$uuid"
-        if [ $? -eq 0 ]; then
-            $print_uuid
-        fi
         ;;
     undefine)
         if [ -z "$uuid" ]; then
@@ -668,6 +662,8 @@ case "$cmd" in
         else
             find "$persist_base" -name "$uuid" -type f | xargs rm -f
         fi
+
+        exit 0
         ;;
     modify)
         if [ -z "$uuid" ]; then
@@ -738,8 +734,6 @@ case "$cmd" in
 
             del_attr_index "$index"
         fi
-
-        write_config "$file"
         ;;
     start)
         set -o errexit
@@ -835,10 +829,6 @@ case "$cmd" in
         if [ -z "$uuid" ]; then
             usage
         fi
-
-        set -o errexit
-
-        remove_mdev "$uuid"
         ;;
     list)
         json="[]"
@@ -1007,5 +997,22 @@ case "$cmd" in
         else
             echo -en "$txt"
         fi
+        ;;
+esac
+
+case "$cmd" in
+    define)
+        write_config "$persist_base/$parent/$uuid"
+        if [ $? -eq 0 ]; then
+            $print_uuid
+        fi
+        ;;
+    modify)
+        write_config "$file"
+        ;;
+    stop)
+        set -o errexit
+
+        remove_mdev "$uuid"
         ;;
 esac

--- a/mdevctl
+++ b/mdevctl
@@ -314,6 +314,163 @@ unique_uuid() {
     echo "$uuid"
 }
 
+callout_script="$persist_base/callouts/scripts.d"
+callout_notification="$persist_base/notification/notifiers.d"
+
+state="none"
+
+dir_is_empty() {
+    path="$1"
+
+    if [ -n "$(ls "$path")" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Not all commands provide all necessary info for the callouts
+# Some sysfs devices need some extra work
+load_device_parameters() {
+    uuid="$1"
+    parent="$2"
+    type="$3"
+    cmd="$4"
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    # Populate $parent for modify, start, and stop.
+    # Define will always have $parent populated prior to this function.
+    if [ -z "$parent" ]; then
+        if [ "$cmd" == "stop" ]; then
+            if [ -d "$mdev_base/$uuid" ]; then
+                parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
+                type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
+            fi
+        else
+            # We arrive here when populating $parent for start or modify.
+            # There must be only one config file exists for $uuid.
+            # Otherwise error will occur if no config or multiple configs for $uuid.
+            file_path=$(echo $(find "$persist_base" -name "$uuid" -type f))
+            parent=$(basename $(realpath "$file_path" | sed -s "s/\/$uuid//"))
+        fi
+
+        # Can't continue this function without populating $parent
+        if [ -z "$parent" ]; then
+            return 1
+        fi
+    fi
+
+    if [ $(echo "$config" | jq 'length') -eq 0 ]; then
+        # We arrive here when starting or stopping a device that does
+        # not have a defined config file.
+        # In that case, $config has not yet been populated before the initial
+        # callout, and we need to populate it with the parameters that were
+        # passed by the user.
+        if [ ! -e "$persist_base/$parent/$uuid" ]; then
+            set_config_key mdev_type "$type"
+            set_config_key start 'manual'
+        else
+        # We arrive here when stopping a device.
+        # Again, $config has not yet been populated before the
+        # initial callout, but we can simply read the existing
+        # config file to populate it.
+            read_config "$persist_base/$parent/$uuid"
+        fi
+    fi
+
+    if [ -z "$type" ]; then
+        type="$(get_config_key mdev_type)"
+    fi
+
+    return 0
+}
+
+callout() {
+    event="$1"
+    action="$2"
+    uuid="$3"
+    parent="$4"
+    type="$5"
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    if dir_is_empty "$callout_script"; then
+        return 0
+    fi
+
+    if [ -z "$type" ]; then
+        return 0
+    fi
+
+    # Save content of $config to $conf variable
+    # Allow scripts to check the device configuration
+    # even after the device removed from the system
+    if [ -z "$conf" ]; then
+        conf=$(dump_config)
+    fi
+
+    set -o pipefail
+
+    if [ -z "$script" ]; then
+        for s in $callout_script/*; do
+            echo "$conf" | $s -t "$type" -e "$event" -a "$action" -s "$state" -u "$uuid" -p "$parent" 2>&1 > /dev/null |
+            sed "s/^/$(basename $(realpath "$s")): /" >&2
+            rc=$?
+            if [ $rc -ne 95 ]; then
+                script=$s
+                break
+            fi
+        done
+    else
+        echo "$conf" | $script -t "$type" -e "$event" -a "$action" -s "$state" -u "$uuid" -p "$parent" 2>&1 > /dev/null |
+        sed "s/^/$(basename $(realpath "$script")): /" >&2
+        rc=$?
+    fi
+
+    return $rc
+}
+
+callout_notify() {
+    action="$1"
+    uuid="$2"
+    parent="$3"
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    if dir_is_empty "$callout_notification"; then
+        return 0
+    fi
+
+    # Save content of $config to $conf variable
+    # Allow scripts to check the device configuration
+    # even after the device removed from the system
+    if [ -z "$conf" ]; then
+        conf=$(dump_config)
+    fi
+
+    set -o pipefail
+
+    for n in $callout_notification/*; do
+        echo "$conf" | $n -e "notify" -a "$action" -s "$state" -u "$uuid" -p "$parent" 2>&1 |
+        sed "s/^/$(basename $(realpath "$n")): /"
+    done
+
+    return 0
+}
+
 usage() {
     cat >&2 <<EOF
 Usage: $(basename $0) {COMMAND} [options...]
@@ -1000,6 +1157,14 @@ case "$cmd" in
         ;;
 esac
 
+load_device_parameters "$uuid" "$parent" "$type" "$cmd"
+
+callout "pre" "$cmd" "$uuid" "$parent" "$type"
+if [ $? -ne 0 ]; then
+    callout_notify "$cmd" "$uuid" "$parent" "$type"
+    exit 0
+fi
+
 case "$cmd" in
     define)
         write_config "$persist_base/$parent/$uuid"
@@ -1011,8 +1176,19 @@ case "$cmd" in
         write_config "$file"
         ;;
     stop)
-        set -o errexit
-
         remove_mdev "$uuid"
         ;;
 esac
+if [ $? -eq 0 ]; then
+    state="success"
+    ec=0
+else
+    state="failure"
+    ec=1
+fi
+
+callout "post" "$cmd" "$uuid" "$parent" "$type"
+
+callout_notify "$cmd" "$uuid" "$parent" "$type"
+
+exit $ec

--- a/mdevctl
+++ b/mdevctl
@@ -318,6 +318,25 @@ callout_script="$persist_base/callouts/scripts.d"
 callout_notification="$persist_base/notification/notifiers.d"
 
 state="none"
+get_attr=[]
+
+build_config() {
+    uuid="$1"
+    parent="$2"
+    type="$3"
+
+    set_config_key mdev_type "$type"
+    set_config_key start 'manual'
+
+    if [ "$attrs" == [] ]; then
+        callout_get "get" "attributes" "$uuid" "$parent" "$type"
+        if [ $? -eq 0 ]; then
+            if [ "$get_attr" != [{}] ]; then
+                attrs=$get_attr
+            fi
+        fi
+    fi
+}
 
 dir_is_empty() {
     path="$1"
@@ -372,8 +391,7 @@ load_device_parameters() {
         # callout, and we need to populate it with the parameters that were
         # passed by the user.
         if [ ! -e "$persist_base/$parent/$uuid" ]; then
-            set_config_key mdev_type "$type"
-            set_config_key start 'manual'
+            build_config "$uuid" "$parent" "$type"
         else
         # We arrive here when stopping a device.
         # Again, $config has not yet been populated before the
@@ -435,6 +453,40 @@ callout() {
         sed "s/^/$(basename $(realpath "$script")): /" >&2
         rc=$?
     fi
+
+    return $rc
+}
+
+callout_get() {
+    local event="$1"
+    local action="$2"
+    local uuid="$3"
+    local parent="$4"
+    local type="$5"
+
+    set +o errexit
+
+    if [ -z "$uuid" ]; then
+        return
+    fi
+
+    if dir_is_empty "$callout_script"; then
+        return 0
+    fi
+
+    if [ -z "$type" ]; then
+        return 0
+    fi
+
+    set -o pipefail
+
+    for s in $callout_script/*; do
+        get_attr=$($s -t "$type" -e "$event" -a "$action" -s "none" -u "$uuid" -p "$parent")
+        rc=$?
+        if [ $rc -ne 95 ]; then
+            break
+        fi
+    done
 
     return $rc
 }
@@ -816,6 +868,17 @@ case "$cmd" in
             mkdir -p "$persist_base/$parent"
             set_config_key mdev_type "$type"
             set_config_key start "$start"
+
+            if [ -e "$mdev_base/$uuid" ]; then
+                callout_get "get" "attributes" "$uuid" "$parent" "$type"
+                if [ $? -eq 0 ]; then
+                    if [ "$get_attr" != [{}] ]; then
+                        attrs=$get_attr
+                    fi
+                else
+                    exit 1
+                fi
+            fi
         fi
         ;;
     undefine)
@@ -1105,6 +1168,20 @@ case "$cmd" in
 
                 json_tmp="{\"$p\":[{\"$u\":{\"mdev_type\":\"$type\"}}]}"
                 txt+="$u $p $type"
+
+                if [ -n "$dumpjson" ]; then
+                    callout_get "get" "attributes" "$u" "$p" "$type"
+                    if [ $? -eq 0 ]; then
+                        if [ "$get_attr" != [] ]; then # callout_get script has been invoked
+                            if [ "$get_attr" == [{}] ]; then
+                                get_attr=[]
+                            fi
+
+                            json_tmp=$(echo "$json_tmp" | jq --argjson att "{\"attrs\":$get_attr}" \
+                                    --arg p "$p" '(.[$p] | .[] | .[]) += $att')
+                        fi
+                    fi
+                fi
 
                 if [ -f "$persist_base/$p/$u" ]; then
                     read_config "$persist_base/$p/$u"

--- a/mdevctl
+++ b/mdevctl
@@ -609,53 +609,48 @@ case "$cmd" in
                 exit 1
             fi
 
-            write_config "$persist_base/$parent/$uuid"
-            if [ $? -ne 0 ]; then
-                exit 1
-            fi
+        else
 
-            $print_uuid
-            exit 0
-        fi
+            if [ -n "$uuid" ]; then
+                if [ -z "$parent" ]; then
+                    if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
+                        usage
+                    fi
 
-        if [ -n "$uuid" ]; then
-            if [ -z "$parent" ]; then
-                if [ ! -L "$mdev_base/$uuid" ] || [ -n "$type" ]; then
-                    usage
+                    parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
+                    type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
                 fi
 
-                parent=$(basename $(realpath "$mdev_base/$uuid" | sed -s "s/\/$uuid//"))
-                type=$(basename $(realpath "$mdev_base/$uuid/mdev_type"))
+                if [ -e "$persist_base/$parent/$uuid" ]; then
+                    echo "Device $uuid on $parent already defined, try modify?" >&2
+                    exit 1
+                fi
+            else
+                uuid=$(unique_uuid)
+                print_uuid="echo $uuid"
             fi
 
-            if [ -e "$persist_base/$parent/$uuid" ]; then
-                echo "Device $uuid on $parent already defined, try modify?" >&2
-                exit 1
+            if [ -z "$parent" ]; then
+                usage
             fi
-        else
-            uuid=$(unique_uuid)
-            print_uuid="echo $uuid"
+
+            if [ -z "$type" ]; then
+                usage
+            fi
+
+            if [ -n "$auto" ]; then
+                start="auto"
+            else
+                start="manual"
+            fi
+
+            set -o errexit
+
+            mkdir -p "$persist_base/$parent"
+            set_config_key mdev_type "$type"
+            set_config_key start "$start"
         fi
 
-        if [ -z "$parent" ]; then
-            usage
-        fi
-
-        if [ -z "$type" ]; then
-            usage
-        fi
-
-        if [ -n "$auto" ]; then
-            start="auto"
-        else
-            start="manual"
-        fi
-
-        set -o errexit
-
-        mkdir -p "$persist_base/$parent"
-        set_config_key mdev_type "$type"
-        set_config_key start "$start"
         write_config "$persist_base/$parent/$uuid"
         if [ $? -eq 0 ]; then
             $print_uuid
@@ -778,60 +773,59 @@ case "$cmd" in
 
             type="$(get_config_key mdev_type)"
 
-            start_mdev "$uuid" "$parent" "$type" "$print_uuid"
-            exit $?
-        fi
+        else
 
-        # We don't implement a placement policy
-        if [ -n "$type" ] && [ -z "$parent" ]; then
-            usage
-        fi
-
-        # The device is not fully specified without TYPE, we must find
-        # a config file, with optional PARENT for disambiguation
-        if [ -z "$type" ] && [ -n "$uuid" ]; then
-            count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
-            if [ "$count" -eq 0 ]; then
-                echo "Config for $uuid does not exist, define it first?" >&2
-                exit 1
-            elif [ "$count" -gt 1 ]; then
-                if [ -z "$parent" ] || [ ! -e "$persist_base/$parent/$uuid" ]; then
-                    echo "Multiple configs found for $uuid, specify a parent" >&2
-                    exit 1
-                fi
-                file="$persist_base/$parent/$uuid"
-            else
-                file=$(find "$persist_base" -name "$uuid" -type f)
-                if [ -n "$parent" ]; then
-                    cur_parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
-                    if [ "$cur_parent" != "$parent" ]; then
-                        echo "Config for $parent/$uuid does not exist, define it first?" >&2
-                        exit 1
-                    fi
-                fi
-            fi
-
-            read_config "$file"
-            if [ $? -ne 0 ]; then
-                echo "Config file $file invalid" >&2
-                exit 1
-            fi
-
-            if [ -z "$parent" ]; then
-                parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
-            fi
-
-            type="$(get_config_key mdev_type)"
-        fi
-
-        if [ -z "$uuid" ]; then
-            # Device must be full specified otherwise for generated UUID
-            if [ -z "$parent" ] || [ -z "$type" ]; then
-                echo "Device is insufficiently specified" >&2
+            # We don't implement a placement policy
+            if [ -n "$type" ] && [ -z "$parent" ]; then
                 usage
             fi
-            uuid=$(unique_uuid)
-            print_uuid="echo $uuid"
+
+            # The device is not fully specified without TYPE, we must find
+            # a config file, with optional PARENT for disambiguation
+            if [ -z "$type" ] && [ -n "$uuid" ]; then
+                count=$(find "$persist_base" -name "$uuid" -type f | wc -l)
+                if [ "$count" -eq 0 ]; then
+                    echo "Config for $uuid does not exist, define it first?" >&2
+                    exit 1
+                elif [ "$count" -gt 1 ]; then
+                    if [ -z "$parent" ] || [ ! -e "$persist_base/$parent/$uuid" ]; then
+                        echo "Multiple configs found for $uuid, specify a parent" >&2
+                        exit 1
+                    fi
+                    file="$persist_base/$parent/$uuid"
+                else
+                    file=$(find "$persist_base" -name "$uuid" -type f)
+                    if [ -n "$parent" ]; then
+                        cur_parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
+                        if [ "$cur_parent" != "$parent" ]; then
+                            echo "Config for $parent/$uuid does not exist, define it first?" >&2
+                            exit 1
+                        fi
+                    fi
+                fi
+
+                read_config "$file"
+                if [ $? -ne 0 ]; then
+                    echo "Config file $file invalid" >&2
+                    exit 1
+                fi
+
+                if [ -z "$parent" ]; then
+                    parent=$(basename $(echo "$file" | sed -s "s/\/$uuid//"))
+                fi
+
+                type="$(get_config_key mdev_type)"
+            fi
+
+            if [ -z "$uuid" ]; then
+                # Device must be full specified otherwise for generated UUID
+                if [ -z "$parent" ] || [ -z "$type" ]; then
+                    echo "Device is insufficiently specified" >&2
+                    usage
+                fi
+                uuid=$(unique_uuid)
+                print_uuid="echo $uuid"
+            fi
         fi
 
         start_mdev "$uuid" "$parent" "$type" "$print_uuid"

--- a/mdevctl.8
+++ b/mdevctl.8
@@ -382,11 +382,168 @@ e2e73122-cc39-40ee-89eb-b0a47d334cae matrix vfio_ap-passthrough manual
     @{2}: {"assign_domain":"0xff"}
 .EE
 
+.SH EXTERNAL SCRIPTS FOR DEVICE EVENTS
+
+.SS SYNOPSIS
+<CONFIG> | SCRIPT <\fB-t=\fR\fItype\fR \fB-e=\fR\fIevent\fR
+\fB-a=\fR\fIaction\fR \fB-s=\fR\fIstatus\fR \fB-u=\fR\fIUUID\fR
+\fB-p=\fR\fIparent\fR>
+
+.SS DESCRIPTION
+
+mdevctl supports invoking external scripts to handle additional device-specific
+configuration and event reporting. These scripts are invoked by mdevctl at
+various points during command execution depending on the "event" type and an
+"action". The scripts are also provided a "status" flag regarding the mdevctl's
+command success/failure (or "none" if the command was not executed), and the
+device's "TYPE", "UUID", "PARENT". The device's JSON configuration is provided
+via standard input.
+
+These scripts are invoked before and after an mdevctl's "primary command
+execution" (e.g. writing the device configuration file during define, or
+activating a device during start).
+
+All errors are redirected to standard error (except for auto-start call-out
+errors, which are reported to systemd).
+
+Essentially, the procedure in mdevctl looks like this:
+
+.RS
+.IP "1. command-line parsing & setup"
+.IP "2. invoke pre-command call-out"
+.IP "3. primary command execution*"
+.IP "4. invoke post-command call-out*"
+.IP "5. invoke notifier"
+.IP "* step is skipped if 2 fails."
+.RE
+
+.SS CALL-OUT EVENTS
+Call-out event scripts are invoked with the following parameters below. For
+"pre", "post", and "get" call-outs, the "TYPE" parameter must be checked
+to ensure the device is supported by the script and return an error otherwise
+(detailed below).
+
+.PP
+\fBPre-Command: \fR
+<\fICONFIG\fR> | SCRIPT \fR
+<\fB-t=\fR\fITYPE\fR \fB-e=\fR\fI"pre"\fR \fB-a=\fR\fIACTION\fR
+\fB-s=\fR\fI"none"\fR \fB-u=\fR\fIUUID\fR \fB-p=\fR\fIPARENT\fR>
+.RS 4
+A pre-command call-out is invoked once prior to primary command execution.
+This event will be paired with an action reflecting an mdevctl command and
+a status of "none". A non-zero return code will cause mdevctl to fire off
+a notification event (see below) and exit early. This event is not supported
+for the \fBlist\fR, \fBtypes\fR, or \fBversion\fR commands.
+.RE
+
+.PP
+\fBPost-Command: \fR
+<\fICONFIG\fR> | SCRIPT \fR
+<\fB-t=\fR\fITYPE\fR \fB-e=\fR\fI"post"\fR \fB-a=\fR\fIACTION\fR
+\fB-s=\fR\fI"success"\fR|\fI"failure"\fR \fB-u=\fR\fIUUID\fR
+\fB-p=\fR\fIPARENT\fR>
+.RS 4
+A post-command call-out is invoked once after primary command execution.
+The action will reflect an mdevctl command. This event will be paired with
+a status of "success" if mdevctl returned a 0 during a primary command
+execution subroutine, or "failure" otherwise. A non-zero return code is
+ignored. This event is not supported for the \fBlist\fR, \fBtypes\fR, or
+\fBversion\fR commands.
+.RE
+
+.PP
+\fBAuto-start: \fR
+<\fICONFIG\fR> | SCRIPT \fR
+<\fB-t=\fR\fITYPE\fR \fB-e=\fR\fI"pre"\fR|\fI"post"\fR\ \fB-a=\fR\fI"start"\fR
+\fB-s=\fR\fI"success"\fR|\fI"failure"\fR \fB-u=\fR\fIUUID\fR
+\fB-p=\fR\fIPARENT\fR>
+.RS 4
+For auto-start devices, a pre/post-command call-out is made for each device.
+The parameters are the same as for a "start" command. The pre-command event is
+non-disruptive in this case as to allow mdevctl to attempt each device.
+All errors reported by the pre/post events are redirected to systemd.
+.RE
+
+.PP
+\fBGet-attributes: \fR
+<\fICONFIG\fR> | SCRIPT \fR
+<\fB-t=\fR\fITYPE\fR \fB-e=\fR\fI"get"\fR \fB-a=\fR\fI"attributes"\fR
+\fB-s=\fR\fI"none"\fR \fB-u=\fR\fIUUID\fR \fB-p=\fR\fIPARENT\fR>
+.RS 4
+A get call-out is invoked during a \fBdefine\fR and \fBlist\fR command at some
+point to acquire device attributes. This event will be paired with an action of
+"attributes" and a status of "none". For \fBdefine\fR, the script will be
+invoked during the "command line & parsing setup" phase, and a non-zero return
+code will disrupt the define command. For \fblist\fR, any non-zero return will
+be ignored. A script must return a JSON formatted array of device attributes.
+
+Example output:
+
+.EX
+[
+    {
+        \fI"attribute0"\fR: \fI"VALUE"\fR
+    },
+    {
+        \fI"attribute1"\fR: \fI"VALUE"\fR
+    }
+]
+.EE
+.RE
+
+.SS NOTIFICATION EVENT
+Notification event scripts are invoked with the following parameters:
+
+.PP
+\fBNotifier: \fR
+<\fICONFIG\fR> | SCRIPT \fR
+<\fB-e=\fR\fI"notify"\fR \fB-a=\fR\fIACTION\fR
+\fB-s=\fR\fI"none"\fR|\fI"success"\fR|\fI"failure"\fR
+\fB-u=\fR\fIUUID\fR \fB-p=\fR\fIPARENT\fR>
+.RS 4
+A notify call-out is invoked once either after a pre-command call-out failure,
+or after a post-command call-out. The action will reflect an mdevctl command.
+This event will be paired with a status of "none" if invoked after a
+pre-command call-out failure, or "success" or "failure" after a post-command
+call-out.  All installed notification scripts are executed, regardless of
+device type. A non-zero return code is ignored. This event is not supported
+for the \fBlist\fR, \fBtypes\fR, or \fBversion\fR commands.
+.RE
+
+.PP
+\fBAuto-start Notifier: \fR
+<\fICONFIG\fR> | SCRIPT \fR
+<\fB-e=\fR\fI"notify"\fR \fB-a=\fR\fI"start"\fR
+\fB-s=\fR\fI"none"\fR|\fI"success"\fR|\fI"failure"\fR
+\fB-u=\fR\fIUUID\fR \fB-p=\fR\fIPARENT\fR>
+.RS 4
+A notifier will be invoked during the auto-start events using the "start"
+action. Note that if a notification script is used to convey information to
+another program or daemon during the auto-start procedure, it is not
+guaranteed that the program will be started prior to mdevctl's invocation.
+.RE
+
+.SS SCRIPT RETURN VALUES
+
+.RS
+.IP "0  if OK,
+.IP "1  if an error occurred,
+.IP "95  if the script does not support the device type
+.RE
+
 .SH FILES
 \fI/etc/mdevctl.d/*\fR
 
 Configuration files are in one subdirectory per parent device and named
 by UUID.
+
+\fI/etc/mdevctl.d/callouts/scripts.d/*\fR
+
+Scripts for pre/post/get call-out events.
+
+\fI/etc/mdevctl.d/notifications/notifiers.d/*\fR
+
+Scripts for notification call-out events.
 
 .SH "CONFIGURATION FILE FORMAT"
 


### PR DESCRIPTION
Version 2 of the call-out implementation. Previous version is #32.

We are aware of the mdevctl-experimental project, but would still like to propose this as a core functionality of mdevctl (present and future) to allow for device-specific configurations.

Changelog:
 - moved the bulk of the documentation from README to the man page
 - included a basic logger notifier script as an example of the call-out functionality
 - restructured commits
    - call-outs for define, modify, and stop are rather straight-forward and are supported via a single patch
    - call-outs for manual/auto start is a patch on its own to underline the auto-start special case
    - call-outs for undefine is also a patch on its own since it needs to be handled differently than the other commands due to handling multiple devices at once
       - Handle undefine in the first command block
       - Invoke callout scripts before and after removing each config file.
 - "locator script" concept is dropped
    - all call-out scripts for pre/post/get events are now stored in /etc/mdevctl.d/callouts/scripts.d/
 - The new callout script API format:  `echo "$conf" | $script -t "$type" -e "$event" -a "$action" -s "$state" -u "$uuid" -p "$parent"`
    - pre/post/get now passes device type as the first parameter, this should be the first thing the script checks to confirm if it supports the  device type, returning EOPNOTSUPP (95) otherwise.
    - notify is unchanged
 - replaced systemd-cat with logger utility
 - exit code from mdevctl now reflects SUCCESS/FAILURE state for define, start, stop, and modify
 - various code cleanups