### PR TITLE
Fix define from jsonfile

### DIFF
--- a/mdevctl
+++ b/mdevctl
@@ -609,6 +609,7 @@ case "$cmd" in
                 exit 1
             fi
 
+            mkdir -p "$persist_base/$parent"
             write_config "$persist_base/$parent/$uuid"
             if [ $? -ne 0 ]; then
                 exit 1


### PR DESCRIPTION
Using a jsonfile like this
$ cat mdev_nodedev.json
{"mdev_type": "vfio-ccw_io", "start": "manual", "attrs":[]}

and calling mdevctl to define a definition as follows causes an error.
$ mdevctl define -p 0.0.0033 --jsonfile mdev_nodedev.json
/usr/sbin/mdevctl: line 183: /etc/mdevctl.d/0.0.0033/532d626a-40bb-4cc1-a8f5-3291b42039ed: No such file or directory

This is due a missing subdirectory creation in the base directory
/etc/mdevctl.d/ before writing the config in the define jsonfile case.

Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>