### PR TITLE
[v3] Callouts (rust impl)

### DIFF
--- a/60-mdevctl.rules
+++ b/60-mdevctl.rules
@@ -1,8 +1,8 @@
 # When registered with mdev, try to start any persistent devices. Note that
 # this uevent is not triggered on older kernels.
-ACTION=="change", ENV{MDEV_STATE}=="registered", TEST=="/etc/mdevctl.d/$kernel", RUN+="/bin/sh -c '/usr/sbin/mdevctl start-parent-mdevs %k'"
+ACTION=="change", ENV{MDEV_STATE}=="registered", TEST=="/etc/mdevctl.d/$kernel", RUN+="/bin/sh -c '{ /usr/sbin/mdevctl start-parent-mdevs %k 2>&3 | logger -t mdevctl; } 3>&1 1>&2 | logger -t mdevctl -p 2'"
 
 # For compatibility with kernels where mdev doesn't trigger the change uevent
 # on parent device registration, try to start mdevs when the device is added;
 # if the device is setup early this may still work.
-ACTION=="add", TEST=="/etc/mdevctl.d/$kernel", RUN+="/bin/sh -c '/usr/sbin/mdevctl start-parent-mdevs %k'"
+ACTION=="add", TEST=="/etc/mdevctl.d/$kernel", RUN+="/bin/sh -c '{ /usr/sbin/mdevctl start-parent-mdevs %k 2>&3 | logger -t mdevctl; } 3>&1 1>&2 | logger -t mdevctl -p 2'"

--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@ UDEVDIR=$(shell pkg-config --variable=udevdir udev)
 SBINDIR=$(PREFIX)/sbin
 CONFDIR=/etc/mdevctl.d
 CALLOUT_CMD_DIR=$(CONFDIR)/scripts.d/callouts
+CALLOUT_NOTIFIER_DIR=$(CONFDIR)/scripts.d/notifiers
 DATADIR=$(PREFIX)/share
 MANDIR=$(DATADIR)/man
 BASH_COMPLETION_DIR=$(DATADIR)/bash-completion/completions
@@ -50,3 +51,4 @@ install:
 	install -m 644 -T @@mdevctl.bash@@ $(DESTDIR)$(BASH_COMPLETION_DIR)/mdevctl
 	install -m 644 -T @@lsmdev.bash@@ $(DESTDIR)$(BASH_COMPLETION_DIR)/lsmdev
 	mkdir -p $(DESTDIR)$(CALLOUT_CMD_DIR)
+	mkdir -p $(DESTDIR)$(CALLOUT_NOTIFIER_DIR)

--- a/Makefile.in
+++ b/Makefile.in
@@ -4,6 +4,7 @@ PREFIX?=/usr
 UDEVDIR=$(shell pkg-config --variable=udevdir udev)
 SBINDIR=$(PREFIX)/sbin
 CONFDIR=/etc/mdevctl.d
+CALLOUT_CMD_DIR=$(CONFDIR)/scripts.d/callouts
 DATADIR=$(PREFIX)/share
 MANDIR=$(DATADIR)/man
 BASH_COMPLETION_DIR=$(DATADIR)/bash-completion/completions
@@ -48,3 +49,4 @@ install:
 	mkdir -p $(DESTDIR)$(BASH_COMPLETION_DIR)/
 	install -m 644 -T @@mdevctl.bash@@ $(DESTDIR)$(BASH_COMPLETION_DIR)/mdevctl
 	install -m 644 -T @@lsmdev.bash@@ $(DESTDIR)$(BASH_COMPLETION_DIR)/lsmdev
+	mkdir -p $(DESTDIR)$(CALLOUT_CMD_DIR)

--- a/mdevctl.8
+++ b/mdevctl.8
@@ -390,12 +390,6 @@ e2e73122-cc39-40ee-89eb-b0a47d334cae matrix vfio_ap-passthrough manual
     @{2}: {"assign_domain":"0xff"}
 .EE
 
-.SH FILES
-\fI/etc/mdevctl.d/*\fR
-
-Configuration files are in one subdirectory per parent device and named
-by UUID.
-
 .SH "CONFIGURATION FILE FORMAT"
 
 Configuration files are in JSON. Attributes in \fB"attrs"\fR are optional.
@@ -414,6 +408,226 @@ Configuration files are in JSON. Attributes in \fB"attrs"\fR are optional.
   ]
 }
 .EE
+
+.SH INVOKING EXTERNAL SCRIPTS FOR DEVICE EVENTS
+
+mdevctl supports invoking external scripts to handle additional device
+type-specific configurations and to broadcast notifications regarding changes
+or updates to a device. These scripts are invoked before, after, and/or during
+mdevctl's "primary command execution" (e.g. writing the device configuration
+file for define, or activating a device for start).
+
+Essentially, the procedure in mdevctl looks like this:
+
+.RS
+.IP "1. command-line parsing & setup"
+.IP "2. invoke pre-command call-out"
+.IP "3. primary command execution*"
+.IP "4. invoke post-command call-out*"
+.IP "5. invoke notifier"
+.IP "* skipped if step 2 fails."
+.RE
+
+.SS EVENT SCRIPTS
+
+A call-out or notification event invokes a script along with a set of
+parameters detailing the type of call-out, mdevctl's command execution
+progress, and the mediated device. The parameters are as follows:
+
+<CONFIG> | SCRIPT <\fB-t=\fR\fItype\fR \fB-e=\fR\fIevent\fR
+\fB-a=\fR\fIaction\fR \fB-s=\fR\fIstate\fR \fB-u=\fR\fIUUID\fR
+\fB-p=\fR\fIparent\fR>
+
+.PP
+\fBCONFIG\fR
+.RS 4
+The device's JSON configuration, provided via standard input.
+.RE
+
+.PP
+\fB-t=\fR\fItype\fR
+.RS 4
+The device type.
+.RE
+
+.PP
+\fB-e=\fR\fIevent\fR
+.RS 4
+Event type of call-out that is invoked. For call-out scripts, this may be
+\fBpre\fR, \fBpost\fR, or \fBget\fR. For notification scripts, this will
+always be \fBnotify\fR.
+.RE
+
+.PP
+\fB-a=\fR\fIaction\fR
+.RS 4
+An action synonymous with an mdevctl command (e.g. define, start).
+.RE
+
+.PP
+\fB-s=\fR\fIstate\fR
+.RS 4
+A trinary state of the mdevctl command execution. The possibilities are
+\fBnone\fR if the mdevctl command has yet to execute, \fBsuccess\fR
+if the mdevctl command completed successfully, or \fBfailure\fR if there
+was a problem executing the mdevctl command.
+.RE
+
+.PP
+\fB-u=\fR\fIUUID\fR
+.RS 4
+UUID of the mediated device.
+.RE
+
+.PP
+\fB-p=\fR\fIparent\fR>
+.RS 4
+Parent of the mediated the device.
+.RE
+
+.SS CALL-OUT EVENT SCRIPTS
+
+A call-out event script is invoked during a \fBpre\fR, \fBpost\fR, or \fBget\fR
+event. mdevctl will attempt each script stored in the mdevctl callouts
+directory until either a script that satisfies the device type is found or all
+scripts have been attempted. A device script must check the "TYPE" parameter to
+ensure the specified device type is supported, otherwise error code 2 should be
+returned. If no script is found for the specified device type, then mdevctl
+will carry on as normal.
+
+These scripts are stored in \fI/etc/mdevctl.d/scripts.d/callouts\fR. The same
+script is invoked for \fBpre\fR, \fBpost\fR, and \fBget\fR call-out events for
+the device type.
+
+.PP
+\fBPre-Command\fR
+.RS 4
+
+A pre-command call-out event is invoked once prior to primary command execution.
+Event type is \fBpre\fR. Status will always be \fBnone\fR.
+
+Any non-zero return code (exempting 2) will prevent mdevctl from performing
+the primary command execution and mdevctl will abort early.
+
+A notification event will follow only if an error code (exempting 2) is
+observed.
+
+This event is not supported for the \fBlist\fR, \fBtypes\fR, or \fBversion\fR
+commands.
+.RE
+
+.PP
+\fBPost-Command\fR
+.RS 4
+
+A post-command call-out event is invoked once after primary command execution.
+Event type is \fBpost\fR. Status will be \fBsuccess\fR if mdevctl was able to
+finish primary command execution successfully, or \fBfailure\fR otherwise.
+
+The same script used for the pre event is used for the post event.
+
+Any return code is non-disruptive.
+
+A notification event will always follow a post-command call-out.
+
+This event is not supported for the \fBlist\fR, \fBtypes\fR, or \fBversion\fR
+commands.
+.RE
+
+.PP
+\fBGet-attributes\fR
+.RS 4
+
+A get event is invoked during a \fBdefine\fR and \fBlist\fR command to
+acquire device attributes from an active device. Event type is \fBget\fR. Action
+is \fBattributes\fR. Status is \fBnone\fR. Note that, unlike other call-outs
+events, \fBget-attributes does not expect a device config on stdin, and an
+array of JSON formatted device attributes is returned via stdout\fR.
+
+The same script used for the pre event is used for the get event. If the script
+is not designed to support a get event, then the return code is 0.
+
+For \fBdefine\fR, a non-zero return code (exempting 2) will disrupt the define
+command entirely.
+
+For \fBlist\fR, any return code is non-disruptive.
+
+A script must return a JSON formatted array of device attributes on standard
+output. Example:
+
+.EX
+[
+    {
+        \fI"attribute0"\fR: \fI"VALUE"\fR
+    },
+    {
+        \fI"attribute1"\fR: \fI"VALUE"\fR
+    }
+]
+.EE
+.RE
+
+.SS AUTO-START CALL-OUTS
+
+For each device set to start automatically during system boot, mdevctl will
+invoke the pre and post events. Action is the string \fBstart\fR.
+
+Return code and notification event behavior is the same as documented for
+the pre and post events. Errors reported by a script will disrupt the
+auto-start for that particular device and the message will be reported to the
+system log before attempting to the next auto-start device.
+
+Note that if a notification script is used to convey information to another
+program or daemon during the auto-start procedure, it is not guaranteed that
+the program will already be active prior to mdevctl's invocation (e.g. the
+auto-start event may occur before the libvirt daemon is activated).
+.RE
+
+.SS NOTIFICATION EVENT SCRIPTS
+
+Notification event scripts may be used to signal the state of the mediated
+device or the status of an mdevctl command to other programs or loggers. Unlike
+call-out scripts, notifier scripts are device-type agnostic.
+
+.PP
+\fBNotify\fR
+.RS 4
+
+A notification event is invoked once either following a pre-command call-out
+failure or after a post-command call-out. Event is \fBnotify\fR. If following a
+pre event, then status will be \fBnone\fR. If following a post event, then
+status will mirror the value passed to the post-command call-out.
+
+These scripts are stored in \fI/etc/mdevctl.d/scripts.d/notifiers\fR. \fBAll
+notification scripts will be invoked during a notification event\fR.
+
+A non-zero return code is ignored.
+
+This event is not supported for the \fBlist\fR, \fBtypes\fR, or \fBversion\fR
+commands.
+.RE
+
+.SS SCRIPT RETURN VALUES
+
+.RS
+.IP "0  if OK,
+.IP "1  if an error occurred,
+.IP "2  if the script does not support the device type
+.RE
+
+.SH FILES
+\fI/etc/mdevctl.d/*\fR
+
+Configuration files are in one subdirectory per parent device and named
+by UUID.
+
+\fI/etc/mdevctl.d/scripts.d/callouts/*\fR
+
+Scripts for pre/post/get call-out events.
+
+\fI/etc/mdevctl.d/scripts.d/notifiers/*\fR
+
+Scripts for notification call-out events.
 
 .SH "SEE ALSO"
 \fBudev\fR(7)

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -36,6 +36,7 @@ impl Display for Event {
 }
 
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 pub enum Action {
     Start,
     Stop,
@@ -43,6 +44,7 @@ pub enum Action {
     Undefine,
     Modify,
     Attributes,
+    Test, // used for tests only
 }
 
 impl Display for Action {
@@ -54,6 +56,7 @@ impl Display for Action {
             Action::Undefine => write!(f, "undefine"),
             Action::Modify => write!(f, "modify"),
             Action::Attributes => write!(f, "attributes"),
+            Action::Test => write!(f, "test"),
         }
     }
 }

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -1,0 +1,229 @@
+use anyhow::{anyhow, Context, Result};
+use log::{debug, warn};
+use std::ffi::OsStr;
+use std::fmt::{self, Display, Formatter};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use crate::mdev::*;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Event {
+    Pre,
+    Post,
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Event::Pre => {
+                write!(f, "pre")
+            }
+            Event::Post => {
+                write!(f, "post")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Action {
+    Start,
+    Stop,
+    Define,
+    Undefine,
+    Modify,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Action::Start => write!(f, "start"),
+            Action::Stop => write!(f, "stop"),
+            Action::Define => write!(f, "define"),
+            Action::Undefine => write!(f, "undefine"),
+            Action::Modify => write!(f, "modify"),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum State {
+    None,
+    Success,
+    Failure,
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            State::None => write!(f, "none"),
+            State::Success => write!(f, "success"),
+            State::Failure => write!(f, "failure"),
+        }
+    }
+}
+
+pub struct Callout {
+    state: State,
+    script: Option<PathBuf>,
+}
+
+impl Callout {
+    fn new() -> Callout {
+        Callout {
+            state: State::None,
+            script: None,
+        }
+    }
+
+    pub fn invoke<F>(dev: &mut MDev, action: Action, func: F) -> Result<()>
+    where
+        F: Fn(&mut MDev) -> Result<()>,
+    {
+        let mut c = Callout::new();
+
+        c.callout(dev, Event::Pre, action).and_then(|_| {
+            let tmp_res = func(dev);
+            c.state = match tmp_res {
+                Ok(_) => State::Success,
+                Err(_) => State::Failure,
+            };
+
+            let post_res = c.callout(dev, Event::Post, action);
+            if post_res.is_err() {
+                debug!("Error occurred when executing post callout script");
+            }
+
+            tmp_res
+        })
+    }
+
+    fn invoke_script<P: AsRef<Path>>(
+        &self,
+        dev: &mut MDev,
+        script: P,
+        event: Event,
+        action: Action,
+    ) -> Result<Output> {
+        debug!(
+            "{} callout: executing {:?}",
+            event.to_string(),
+            script.as_ref().as_os_str()
+        );
+
+        let mut cmd = Command::new(script.as_ref().as_os_str());
+
+        cmd.arg("-t")
+            .arg(dev.mdev_type()?)
+            .arg("-e")
+            .arg(event.to_string())
+            .arg("-a")
+            .arg(action.to_string())
+            .arg("-s")
+            .arg(self.state.to_string())
+            .arg("-u")
+            .arg(dev.uuid.to_string())
+            .arg("-p")
+            .arg(dev.parent()?)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn()?;
+
+        let conf = dev.to_json(false)?.to_string();
+        if let Some(mut child_stdin) = child.stdin.take() {
+            child_stdin
+                .write_all(conf.as_bytes())
+                .with_context(|| "Failed to write to stdin of command")?;
+        }
+
+        child.wait_with_output().map_err(anyhow::Error::from)
+    }
+
+    fn print_err<P: AsRef<Path>>(&self, output: &Output, script: P) {
+        let sname = script
+            .as_ref()
+            .file_name()
+            .unwrap_or_else(|| OsStr::new("unknown script name"))
+            .to_string_lossy();
+
+        let st = String::from_utf8_lossy(&output.stderr);
+        if !st.is_empty() {
+            eprint!("{}: {}", &sname, st);
+        }
+    }
+
+    fn invoke_first_matching_script<P: AsRef<Path>>(
+        &self,
+        dev: &mut MDev,
+        dir: P,
+        event: Event,
+        action: Action,
+    ) -> Option<(PathBuf, Output)> {
+        if dir.as_ref().read_dir().ok()?.count() == 0 {
+            return None;
+        }
+
+        for s in dir.as_ref().read_dir().ok()? {
+            let path = s.ok()?.path();
+
+            match self.invoke_script(dev, &path, event, action).ok() {
+                Some(res) => {
+                    if res.status.code().is_none() {
+                        warn!("Script was terminated by a signal");
+                        continue;
+                    } else if res.status.code() != Some(2) {
+                        return Some((path, res));
+                    } else {
+                        debug!(
+                            "Device type {} unmatched by callout script",
+                            dev.mdev_type().ok()?
+                        );
+                    }
+                }
+                _ => {
+                    debug!("failed to execute callout script {:?}", path);
+                    continue;
+                }
+            }
+        }
+        None
+    }
+
+    fn callout(&mut self, dev: &mut MDev, event: Event, action: Action) -> Result<()> {
+        let rc = match self.script {
+            Some(ref s) => self
+                .invoke_script(dev, s, event, action)
+                .ok()
+                .and_then(|output| {
+                    self.print_err(&output, s);
+                    output.status.code()
+                }),
+            _ => {
+                let dir = dev.env.callout_script_base();
+
+                if !dir.is_dir() {
+                    return Ok(());
+                }
+                self.invoke_first_matching_script(dev, dir, event, action)
+                    .and_then(|(path, output)| {
+                        self.print_err(&output, &path);
+                        self.script = Some(path);
+                        output.status.code()
+                    })
+            }
+        };
+
+        match rc {
+            Some(0) | None => Ok(()),
+            Some(n) => Err(anyhow!(
+                "callout script {:?} failed with return code {}",
+                self.script.as_ref().unwrap(),
+                n
+            )),
+        }
+    }
+}

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -21,6 +21,10 @@ pub trait Environment {
     fn parent_base(&self) -> PathBuf {
         self.root().join("sys/class/mdev_bus")
     }
+
+    fn callout_script_base(&self) -> PathBuf {
+        self.persist_base().join("scripts.d/callouts")
+    }
 }
 
 /// A default implementation of the Environment trait which uses '/' as the filesystem root.

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -25,6 +25,10 @@ pub trait Environment {
     fn callout_script_base(&self) -> PathBuf {
         self.persist_base().join("scripts.d/callouts")
     }
+
+    fn callout_notification_base(&self) -> PathBuf {
+        self.persist_base().join("scripts.d/notifiers")
+    }
 }
 
 /// A default implementation of the Environment trait which uses '/' as the filesystem root.

--- a/src/main.rs
+++ b/src/main.rs
@@ -668,7 +668,7 @@ fn start_parent_mdevs_command(env: &dyn Environment, parent: String) -> Result<(
         for child in children {
             if child.autostart {
                 debug!("Autostarting {:?}", child.uuid);
-                if let Err(e) = child.start() {
+                if let Err(e) = Callout::invoke(child, Action::Start, |child| child.start()) {
                     for x in e.chain() {
                         warn!("{}", x);
                     }

--- a/src/mdev.rs
+++ b/src/mdev.rs
@@ -25,7 +25,7 @@ pub struct MDev<'a> {
     pub parent: Option<String>,
     pub mdev_type: Option<String>,
     pub attrs: Vec<(String, String)>,
-    env: &'a dyn Environment,
+    pub env: &'a dyn Environment,
 }
 
 impl<'a> MDev<'a> {

--- a/src/mdev.rs
+++ b/src/mdev.rs
@@ -207,9 +207,9 @@ impl<'a> MDev<'a> {
 
         let mut output = self.uuid.to_hyphenated().to_string();
         output.push(' ');
-        output.push_str(&self.parent()?);
+        output.push_str(self.parent()?);
         output.push(' ');
-        output.push_str(&self.mdev_type()?);
+        output.push_str(self.mdev_type()?);
         output.push(' ');
         output.push_str(match self.autostart {
             true => "auto",
@@ -350,7 +350,7 @@ impl<'a> MDev<'a> {
 
         debug!("Setting attributes for mdev {:?}", self.uuid);
         for (k, v) in self.attrs.iter() {
-            if let Err(e) = write_attr(&self.path(), &k, &v) {
+            if let Err(e) = write_attr(&self.path(), k, v) {
                 self.stop()?;
                 return Err(e);
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -50,6 +50,8 @@ impl TestEnvironment {
         fs::create_dir_all(test.parent_base()).expect("Unable to create parent_base");
         fs::create_dir_all(test.callout_script_base())
             .expect("Unable to create callout_script_base");
+        fs::create_dir_all(test.callout_notification_base())
+            .expect("Unable to create callout_notification_base");
         info!("---- Running test '{}/{}' ----", testname, testcase);
         test
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -48,6 +48,8 @@ impl TestEnvironment {
         fs::create_dir_all(test.mdev_base()).expect("Unable to create mdev_base");
         fs::create_dir_all(test.persist_base()).expect("Unable to create persist_base");
         fs::create_dir_all(test.parent_base()).expect("Unable to create parent_base");
+        fs::create_dir_all(test.callout_script_base())
+            .expect("Unable to create callout_script_base");
         info!("---- Running test '{}/{}' ----", testname, testcase);
         test
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1405,4 +1405,45 @@ fn test_callouts() {
             test.populate_callout_script("rc1.sh");
         },
     );
+    // Expected behavior: script will report that the requested device type / parent does not
+    // match the script's type / parent. mdevctl will continue with regularly scheduled programming.
+    test_invoke_callout(
+        "test_callout_wrong_type",
+        Expect::Pass,
+        Action::Test,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc2.sh");
+        },
+    );
+    // This test is expected to fail. If the correct script is executed, then it will`
+    // return error code 1.
+    test_invoke_callout(
+        "test_callout_type_c",
+        Expect::Fail,
+        Action::Test,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "parent_c",
+        "type_c",
+        |test| {
+            test.populate_callout_script("type-a.sh");
+            test.populate_callout_script("type-b.sh");
+            test.populate_callout_script("type-c.sh");
+        },
+    );
+    test_invoke_callout(
+        "test_callout_no_script",
+        Expect::Pass,
+        Action::Test,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "parent_d",
+        "type_d",
+        |test| {
+            test.populate_callout_script("type-a.sh");
+            test.populate_callout_script("type-b.sh");
+            test.populate_callout_script("type-c.sh");
+        },
+    );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1253,6 +1253,33 @@ fn test_list() {
         Some("nonexistent".to_string()),
         setup,
     );
+
+    // test list with the Get Attributes callout
+    test_list_helper(
+        "active-callout",
+        Expect::Pass,
+        false,
+        false,
+        None,
+        None,
+        |test| {
+            setup(test);
+            test.populate_callout_script("good-json.sh");
+        },
+    );
+    // if a script returns an ill-formatted JSON, then then the output should be ignored
+    test_list_helper(
+        "active-callout-bad-json",
+        Expect::Pass,
+        false,
+        false,
+        None,
+        None,
+        |test| {
+            setup(test);
+            test.populate_callout_script("bad-json.sh");
+        },
+    );
 }
 
 fn test_types_helper(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1446,4 +1446,62 @@ fn test_callouts() {
             test.populate_callout_script("type-c.sh");
         },
     );
+    // Each pre/post function in the test script will check for
+    // a device type and parent with the command name appended
+    // to the end
+    test_invoke_callout(
+        "test_callout_params_define",
+        Expect::Pass,
+        Action::Define,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "test_parent_define",
+        "test_type_define",
+        |test| {
+            test.populate_callout_script("params.sh");
+        },
+    );
+    test_invoke_callout(
+        "test_callout_params_modify",
+        Expect::Pass,
+        Action::Modify,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "test_parent_modify",
+        "test_type_modify",
+        |test| {
+            test.populate_callout_script("params.sh");
+        },
+    );
+    test_invoke_callout(
+        "test_callout_params_start",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "test_parent_start",
+        "test_type_start",
+        |test| {
+            test.populate_callout_script("params.sh");
+        },
+    );
+    test_invoke_callout(
+        "test_callout_params_stop",
+        Expect::Pass,
+        Action::Stop,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "test_parent_stop",
+        "test_type_stop",
+        |test| {
+            test.populate_callout_script("params.sh");
+        },
+    );
+    test_invoke_callout(
+        "test_callout_params_undefine",
+        Expect::Pass,
+        Action::Undefine,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        "test_parent_undefine",
+        "test_type_undefine",
+        |test| {
+            test.populate_callout_script("params.sh");
+        },
+    );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1376,6 +1376,33 @@ fn test_invoke_callout<F>(
     assert!(res.is_ok());
 }
 
+fn test_get_callout<F>(
+    testname: &str,
+    expect: Expect,
+    uuid: Uuid,
+    parent: &str,
+    mdev_type: &str,
+    setupfn: F,
+) where
+    F: Fn(&TestEnvironment),
+{
+    let test = TestEnvironment::new("callouts", testname);
+    setupfn(&test);
+
+    let mut empty_mdev = MDev::new(&test, uuid);
+    empty_mdev.mdev_type = Some(mdev_type.to_string());
+    empty_mdev.parent = Some(parent.to_string());
+
+    let res = Callout::get_attributes(&mut empty_mdev);
+
+    if expect == Expect::Fail {
+        res.expect_err("expected callout to fail");
+        return;
+    }
+
+    assert!(res.is_ok());
+}
+
 #[test]
 fn test_callouts() {
     init();
@@ -1502,6 +1529,27 @@ fn test_callouts() {
         "test_type_undefine",
         |test| {
             test.populate_callout_script("params.sh");
+        },
+    );
+    // test the Get Attributes callouts
+    test_get_callout(
+        "test_callout_good_json",
+        Expect::Pass,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("good-json.sh");
+        },
+    );
+    test_get_callout(
+        "test_callout_bad_json",
+        Expect::Fail,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("bad-json.sh");
         },
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,7 @@ use tempfile::Builder;
 use tempfile::TempDir;
 use uuid::Uuid;
 
+use crate::callouts::*;
 use crate::environment::Environment;
 use crate::logger::logger;
 use crate::mdev::MDev;
@@ -83,6 +84,16 @@ impl TestEnvironment {
 
         let typefile = devdir.join("mdev_type");
         symlink(&parenttypedir, &typefile).expect("Unable to setup mdev type");
+    }
+
+    // set up a script in the test environment to simulate a callout
+    fn populate_callout_script(&self, filename: &str) {
+        let calloutscriptdir: PathBuf = [TEST_DATA_DIR, "callouts"].iter().collect();
+        let calloutscript = calloutscriptdir.join(filename);
+        assert!(calloutscript.exists());
+
+        let dest = self.callout_script_base().join(filename);
+        fs::copy(calloutscript, dest).expect("Unable to copy callout script");
     }
 
     // set up a few files in the test environment to simulate a parent device that supports
@@ -1334,5 +1345,64 @@ fn test_types() {
         "parent-no-match",
         Expect::Pass,
         Some("missing".to_string()),
+    );
+}
+
+fn test_invoke_callout<F>(
+    testname: &str,
+    expect: Expect,
+    action: Action,
+    uuid: Uuid,
+    parent: &str,
+    mdev_type: &str,
+    setupfn: F,
+) where
+    F: Fn(&TestEnvironment),
+{
+    let test = TestEnvironment::new("callouts", testname);
+    setupfn(&test);
+
+    let mut empty_mdev = MDev::new(&test, uuid);
+    empty_mdev.mdev_type = Some(mdev_type.to_string());
+    empty_mdev.parent = Some(parent.to_string());
+
+    let res = Callout::invoke(&mut empty_mdev, action, |_empty_mdev| Ok(()));
+
+    if expect == Expect::Fail {
+        res.expect_err("expected callout to fail");
+        return;
+    }
+
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_callouts() {
+    init();
+
+    const DEFAULT_UUID: &str = "976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9";
+    const DEFAULT_TYPE: &str = "test_type";
+    const DEFAULT_PARENT: &str = "test_parent";
+    test_invoke_callout(
+        "test_callout_all_success",
+        Expect::Pass,
+        Action::Test,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc0.sh");
+        },
+    );
+    test_invoke_callout(
+        "test_callout_all_fail",
+        Expect::Fail,
+        Action::Test,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh");
+        },
     );
 }

--- a/tests/callouts/bad-json.sh
+++ b/tests/callouts/bad-json.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "not json"

--- a/tests/callouts/good-json.sh
+++ b/tests/callouts/good-json.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "[{\"attribute0\": \"VALUE\"}]"

--- a/tests/callouts/params.sh
+++ b/tests/callouts/params.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/bash
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+test_params() {
+    test_parent=$1
+    test_type=$2
+    test_state=$3
+    test_uuid="976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9"
+
+    if [[ "$parent" != "$test_parent" ]]; then
+        exit 1
+    fi
+    if [[ "$type" != "$test_type" ]]; then
+        exit 1
+    fi
+    if [[ "$state" != "$test_state" ]]; then
+        exit 1
+    fi
+    if [[ "$uuid" != "$test_uuid" ]]; then
+        exit 1
+    fi
+    exit 0
+}
+
+case "$event" in
+    pre)
+        case "$action" in
+            define)
+                test_params "test_parent_define" "test_type_define" "none"
+            ;;
+            undefine)
+                test_params "test_parent_undefine" "test_type_undefine" "none"
+            ;;
+            start)
+                test_params "test_parent_start" "test_type_start" "none"
+            ;;
+            stop)
+                test_params "test_parent_stop" "test_type_stop" "none"
+            ;;
+            modify)
+                test_params "test_parent_modify" "test_type_modify" "none"
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    post)
+    case "$action" in
+        define)
+            test_params "test_parent_define" "test_type_define" "success"
+        ;;
+        undefine)
+            test_params "test_parent_undefine" "test_type_undefine" "success"
+        ;;
+        start)
+            test_params "test_parent_start" "test_type_start" "success"
+        ;;
+        stop)
+            test_params "test_parent_stop" "test_type_stop" "success"
+        ;;
+        modify)
+            test_params "test_parent_modify" "test_type_modify" "success"
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/rc0.sh
+++ b/tests/callouts/rc0.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/tests/callouts/rc1.sh
+++ b/tests/callouts/rc1.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 1

--- a/tests/callouts/rc2.sh
+++ b/tests/callouts/rc2.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 2

--- a/tests/callouts/template.sh
+++ b/tests/callouts/template.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+# do stuff here

--- a/tests/callouts/type-a.sh
+++ b/tests/callouts/type-a.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+if [[ "$type" == "type_a" ]]; then
+	exit 0
+fi
+
+exit 2

--- a/tests/callouts/type-b.sh
+++ b/tests/callouts/type-b.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+if [[ "$type" == "type_b" ]]; then
+	exit 0
+fi
+
+exit 2

--- a/tests/callouts/type-c.sh
+++ b/tests/callouts/type-c.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+if [[ "$type" == "type_c" ]]; then
+	exit 1 # this test expects to fail
+fi
+
+exit 2

--- a/tests/list/active-callout-bad-json.json
+++ b/tests/list/active-callout-bad-json.json
@@ -1,0 +1,22 @@
+[
+  {
+    "0000:00:02.0": [
+      {
+        "976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9": {
+          "mdev_type": "arbitrary_type1",
+          "start": "manual",
+          "attrs": []
+        }
+      }
+    ],
+    "0000:00:03.0": [
+      {
+        "59e8b599-afdd-4766-a59e-415ef4f5a492": {
+          "mdev_type": "arbitrary_type2",
+          "start": "manual",
+          "attrs": []
+        }
+      }
+    ]
+  }
+]

--- a/tests/list/active-callout-bad-json.text
+++ b/tests/list/active-callout-bad-json.text
@@ -1,0 +1,2 @@
+976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9 0000:00:02.0 arbitrary_type1 manual
+59e8b599-afdd-4766-a59e-415ef4f5a492 0000:00:03.0 arbitrary_type2 manual

--- a/tests/list/active-callout.json
+++ b/tests/list/active-callout.json
@@ -1,0 +1,30 @@
+[
+  {
+    "0000:00:02.0": [
+      {
+        "976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9": {
+          "mdev_type": "arbitrary_type1",
+          "start": "manual",
+          "attrs": [
+            {
+              "attribute0": "VALUE"
+            }
+          ]
+        }
+      }
+    ],
+    "0000:00:03.0": [
+      {
+        "59e8b599-afdd-4766-a59e-415ef4f5a492": {
+          "mdev_type": "arbitrary_type2",
+          "start": "manual",
+          "attrs": [
+            {
+              "attribute0": "VALUE"
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/tests/list/active-callout.text
+++ b/tests/list/active-callout.text
@@ -1,0 +1,2 @@
+976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9 0000:00:02.0 arbitrary_type1 manual
+59e8b599-afdd-4766-a59e-415ef4f5a492 0000:00:03.0 arbitrary_type2 manual


### PR DESCRIPTION
Version "3" of the call-out implementation. Previous version is #35 

A few notable changes from the previous version (aside from all the rust):

- scripts are now stored in /etc/mdevctl.d/scripts.d/callouts and scripts.d/notifiers
- "script not supported for device type" error code changed from 95 (loosely related to OS error codes) to 2

More documentation can be read via the man page changes, but I'll post it all here so it's easier to read without all the formatting junk:

```
EXTERNAL SCRIPTS FOR DEVICE EVENTS
   SYNOPSIS
       <CONFIG> | SCRIPT <-t=type -e=event -a=action -s=status -u=UUID -p=parent>

   DESCRIPTION
       mdevctl  supports invoking external scripts to handle additional device-specific configuration
       and event reporting. These scripts are invoked by mdevctl at various points during command
       execution depending on the "event" type and an "action". The scripts are also provided a
       "status" flag regarding the mdevctl's command success/failure (or "none" if the command was
       not executed), and the device's "TYPE", "UUID", "PARENT". The device's JSON configuration
       is provided via standard input.

       These scripts are invoked before and after an mdevctl's "primary command execution" (e.g. writing
       the device configuration file during define, or activating a device during start).

       All errors are redirected to stderr (except for auto-start call-out errors,
       which are reported to the system log).

       Essentially, the procedure in mdevctl looks like this:

              1. command-line parsing & setup

              2. invoke pre-command call-out

              3. primary command execution*

              4. invoke post-command call-out*

              5. invoke notifier

              * step is skipped if 2 fails.

   CALL-OUT EVENTS
       Call-out  event scripts are invoked with the following parameters below. For "pre", "post",
       and "get" call-outs, the "TYPE" parameter must be checked by the script to ensure the 
       device type is supported. If the script returns error code 2, denoting that the device type 
       is not supported, then mdevctl will skip the call-out event.

       Pre-Command: <CONFIG> | SCRIPT <-t=TYPE -e="pre" -a=ACTION -s="none" -u=UUID -p=PARENT>

           A pre-command call-out is invoked once prior to primary command execution.
           Action is a string denoting the mdevctl command. Status will always be "none".

           If the call-out script returns with a error code 2, mdevctl will skip the call-out event. 
           Any other non-zero return code will prevent mdevctl from performing the primary 
           command execution, and mdevctl will abort early.

           A notification event will follow only if an error occurred.

           This event is not supported for the list, types, or version commands.

       Post-Command: <CONFIG> | SCRIPT <-t=TYPE -e="post" -a=ACTION -s="success"|"failure" -u=UUID -p=PARENT>

           A post-command call-out is invoked once after to primary command execution.
           Action is a string denoting the mdevctl command. Status will be "success" if
           mdevctl was able to finish primary command execution  successfully,
           or "failure" otherwise.

           A non-zero return code is ignored.

           A notification event will always follow a post-command call-out.

           This event is not supported for the list, types, or version commands.

       Get-attributes: SCRIPT <-t=TYPE -e="get" -a="attributes" -s="none" -u=UUID -p=PARENT>

           A get call-out is invoked during a define and list command to acquire device attributes
           of an active device. Action is the string "attributes". Status will be "none". Note thatm 
           unlike other call-outs, get-attributes does  not expect a device config on stdin.

           For define, a non-zero return code will disrupt the define command entirely.

           For list, any return code will be ignored.

           A script must return a JSON formatted array of device attributes. Example output:

           [
               {
                   "attribute0": "VALUE"
               },
               {
                   "attribute1": "VALUE"
               }
           ]

   NOTIFICATION EVENT
       Notification event scripts may be used to signal the state of the mediated device or the
       status of an mdevctl command to other programs / loggers. A notification event is invoked
       with the following parameters:

       Notifier: <CONFIG> | SCRIPT <-e="notify" -a=ACTION -s="none"|"success"|"failure" -u=UUID -p=PARENT>

           A notify call-out is invoked once either after a pre-command call-out failure, or after a 
           post-command call-out. Action is a string denoting the mdevctl command. If following a
           pre-command call-out, then  status  will  be "none". If following a post-command call-out, 
           then status will be "success" if mdevctl was able to finish primary command execution 
           successfully, or "failure" otherwise.

           All installed notification scripts will be invoked during a notificaiton event.

           A non-zero return code is ignored.

           This event is not supported for the list, types, or version commands.

   AUTO-START CALL-OUTS
       For each device set to start automatically during system boot, mdevctl will invoke the pre-
       and post-command callouts. Action is the string "start".

       Return  code  and notification event behavior is the same as the pre/post-command call-outs, 
       except any error reported by a script will disrupt the auto-start for that particular device and 
       the message will be reported to the system log.

       Note that if a notification script is used to convey information to another program or daemon
       during the auto-start procedure, it is not guaranteed that the program will already be active 
       prior to mdevctl's  invocation  (e.g. auto-start may occur before the libvirt daemon is activated).

   SCRIPT RETURN VALUES
              0  if OK,

              1  if an error occurred,

              2  if the script does not support the device type

FILES
       /etc/mdevctl.d/*

       Configuration files are in one subdirectory per parent device and named by UUID.

       /etc/mdevctl.d/scripts.d/callouts/*

       Scripts for pre/post/get call-out events.

       /etc/mdevctl.d/scripts.d/notifiers/*

       Scripts for notification call-out events.
```
