### PR TITLE
Fix unexpected behavior with 'start'

### DIFF
--- a/mdevctl.8
+++ b/mdevctl.8
@@ -148,11 +148,19 @@ are applied the next time the device is started.
 .PP
 \fBstart\fR \fIDEVICESPEC\fR
 .RS 4
-Start an mdev device, identified by its UUID and optionally its parent,
-or its parent and type and optionally its UUID, which is generated if
-not given.
-If specified via its parent and optionally its UUID, the type may be
-specified in a JSON configuration file, alongside additional parameters.
+Start a mediated device. This command can be used to start either a
+previously-defined device or a newly-created transient device.
+
+If the UUID and optional parent argument matches an existing device definition,
+then the existing device will be started. It is an error to specify a device
+type that conflicts with the existing device definition.
+
+If the UUID argument is omitted or if the specified UUID and parent does not
+match an existing device definition, a new transient device will be started.
+If the UUID is omitted, a new UUID will be automatically generated. When
+starting a new transient device, the parent and device type must be specified.
+A \fB--jsonfile\fR may replace the \fB--type\fR specification and also include
+additional attributes in JSON format to be applied to the started device.
 .RE
 
 .PP

--- a/tests/start/defined-diff-type/defined.json
+++ b/tests/start/defined-diff-type/defined.json
@@ -1,0 +1,4 @@
+{
+  "mdev_type": "arbitrary_type",
+  "start": "manual"
+}

--- a/tests/start/defined-multiple-underspecified/defined.json
+++ b/tests/start/defined-multiple-underspecified/defined.json
@@ -1,0 +1,4 @@
+{
+  "mdev_type": "arbitrary_type",
+  "start": "manual"
+}

--- a/tests/start/defined-multiple-underspecified/defined/defined.json
+++ b/tests/start/defined-multiple-underspecified/defined/defined.json
@@ -1,0 +1,4 @@
+{
+  "mdev_type": "arbitrary_type",
+  "start": "manual"
+}

--- a/tests/start/defined-multiple/defined.json
+++ b/tests/start/defined-multiple/defined.json
@@ -1,0 +1,4 @@
+{
+  "mdev_type": "arbitrary_type",
+  "start": "manual"
+}

--- a/tests/start/defined-with-type/defined.json
+++ b/tests/start/defined-with-type/defined.json
@@ -1,0 +1,4 @@
+{
+  "mdev_type": "arbitrary_type",
+  "start": "manual"
+}

--- a/tests/start/no-type-parent-defined/defined.json
+++ b/tests/start/no-type-parent-defined/defined.json
@@ -1,0 +1,4 @@
+{
+  "mdev_type": "arbitrary_type",
+  "start": "manual"
+}


### PR DESCRIPTION
When running `start` and providing a uuid, parent, and type that match
an existing device definition, mdevctl was creating a new device and
starting that rather than starting the defined device. This normally
doesn't matter unless the defined device contains attributes, in which
case the newly started device won't have the expected attributes set.

Also add some tests to ensure correct behavior in these scenarios.

Fixes #38

Signed-off-by: Jonathon Jongsma <jjongsma@redhat.com>