### PR TITLE
switch tempdir (deprecated) to tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 serde_json = {version = "1.0", features = ["preserve_order"]}
 structopt = "0.3.13"
 uuid = {version = "0.8.2", features = ["v4"]}
-tempdir = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 structopt = "0.3.13"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tempdir::TempDir;
+use tempfile::Builder;
+use tempfile::TempDir;
 use uuid::Uuid;
 
 use crate::environment::Environment;
@@ -38,7 +39,7 @@ impl Environment for TestEnvironment {
 impl TestEnvironment {
     pub fn new(testname: &str, testcase: &str) -> TestEnvironment {
         let path: PathBuf = [TEST_DATA_DIR, testname].iter().collect();
-        let scratchdir = TempDir::new(format!("mdevctl-{}", testname).as_str()).unwrap();
+        let scratchdir = Builder::new().prefix("mdevctl-test").tempdir().unwrap();
         let test = TestEnvironment {
             datapath: path,
             scratch: scratchdir,


### PR DESCRIPTION
Tempdir has been merged with tempfile since tempfile 3.0.
Comparing the two usage codes of the TempDir struct [1] vs [2]
the change appear clear and only needed because mdevctl
uses a prefix (otherwise a change to the use reference would
have been enough).

[1]: https://github.com/rust-lang-deprecated/tempdir
[2]: https://docs.rs/tempfile/3.2.0/tempfile/struct.TempDir.html

Fixes: !44

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>