### PR TITLE
Add a github workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release tasks
+on:
+  release:
+    types: [published]
+jobs:
+  upload-vendor-sources:
+    env:
+      VENDOR_TARBALL: mdevctl-${{ github.event.release.name }}-vendor.tar.gz
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    name: Attach vendor source tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: get vendor sources
+        uses: actions-rs/cargo@v1
+        with:
+          command: vendor
+      - name: package vendor sources
+        run: tar -czvf ${VENDOR_TARBALL} vendor/
+      - name: upload vendor source package
+        run: hub release edit -m "" -a "${VENDOR_TARBALL}" "${{ github.event.release.tag_name }}"
+  publish-crate:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: publish to crates.io
+        uses: katyo/publish-crates@v1
+        with:
+          args: --no-verify
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Add two new github workflow jobs that run when a new release is made.

In order to make packaging easier for downstream linux distributions,
we want to include a separate 'vendor' tarball alongside the mdevctl
source. In order to publish this tarball, add a new github workflow that
runs `cargo vendor` and uploads the vendor tarball to the appropriate
release page.

A second job uploads the new release to crates.io using a token that has
been added to the repository secrets.

Signed-off-by: Jonathon Jongsma <jjongsma@redhat.com>