### PR TITLE
Fix sporadic callout test failures

### DIFF
--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -240,8 +240,8 @@ impl Callout {
         for s in dir.as_ref().read_dir().ok()? {
             let path = s.ok()?.path();
 
-            match self.invoke_script(dev, &path, event, action).ok() {
-                Some(res) => {
+            match self.invoke_script(dev, &path, event, action) {
+                Ok(res) => {
                     if res.status.code().is_none() {
                         warn!("callout script {:?} was terminated by a signal", path);
                         continue;
@@ -255,8 +255,8 @@ impl Callout {
                         );
                     }
                 }
-                _ => {
-                    debug!("failed to execute callout script {:?}", path);
+                Err(e) => {
+                    debug!("failed to execute callout script {:?}: {:?}", path, e);
                     continue;
                 }
             }

--- a/tests/callouts/rc0.sh
+++ b/tests/callouts/rc0.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+json=$(</dev/stdin)
 exit 0

--- a/tests/callouts/rc1.sh
+++ b/tests/callouts/rc1.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+json=$(</dev/stdin)
 exit 1

--- a/tests/callouts/rc2.sh
+++ b/tests/callouts/rc2.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+json=$(</dev/stdin)
 exit 2


### PR DESCRIPTION
Downstream RHEL builds were failing sporadically due to some racy failures in the callout tests. Make the build more deterministic by fixing the race condition.