### PR TITLE
Handle some config filesystem errors

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,7 @@
 //! A filesystem environment for mdevctl
 
+use anyhow::{anyhow, Result};
+use log::debug;
 use std::path::{Path, PathBuf};
 
 /// A trait which provides filesystem paths for certain system resources.
@@ -32,6 +34,22 @@ pub trait Environment {
 
     fn notification_dir(&self) -> PathBuf {
         self.scripts_base().join("notifiers")
+    }
+
+    fn self_check(&self) -> Result<()> {
+        debug!("checking that the environment is sane");
+        // ensure required system dirs exist. Generally distro packages or 'make install' should
+        // create these dirs.
+        for dir in vec![
+            self.persist_base(),
+            self.callout_dir(),
+            self.notification_dir(),
+        ] {
+            if !dir.exists() {
+                return Err(anyhow!("Required directory {:?} doesn't exist. This may indicate a packaging or installation error", dir));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -727,6 +727,10 @@ fn main() -> Result<()> {
 
     let env = DefaultEnvironment::new();
     debug!("{:?}", env);
+
+    // make sure the environment is sane
+    env.self_check()?;
+
     // check if we're running as the symlink executable 'lsmdev'. If so, just execute the 'list'
     // command directly
     let exe = std::env::args_os().next().unwrap();


### PR DESCRIPTION
When there are missing dirs or dirs with insufficient permissions, we weren't providing useful error messages. Make these a little easier to debug.