### PR TITLE
modify: add jsonfile optional parameter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,7 +97,8 @@ pub enum MdevctlCommands {
                 format that is accepted by the attribute. Upon device start, mdevctl will go \
                 through each attribute in order, writing the value into the corresponding sysfs \
                 attribute for the device. The startup mode of the device can also be selected, auto \
-                or manual. \n\n\
+                or manual. Alternatively, the 'jsonfile' option may be used to replace the startup \
+                mode and any attributes with the contents of the specified file.\n\n\
                 Running devices are unaffected by this command."
     )]
     Modify {
@@ -139,6 +140,12 @@ pub enum MdevctlCommands {
             help = "Device must be started manually"
         )]
         manual: bool,
+        #[clap(
+            long, value_parser,
+            conflicts_with_all(&["type", "addattr", "delattr", "index", "value", "auto", "manual"]),
+            help = "Specify device details in JSON format"
+        )]
+        jsonfile: Option<PathBuf>,
     },
     #[clap(
         about = "Start a mediated device",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -553,13 +553,22 @@ fn test_modify_helper<F>(
     value: Option<String>,
     auto: bool,
     manual: bool,
+    jsonfile: Option<PathBuf>,
     setupfn: F,
 ) where
     F: Fn(&TestEnvironment),
 {
     use crate::modify_command;
     let test = TestEnvironment::new("modify", testname);
+
+    // load the jsonfile from the test path.
+    let jsonfile = match jsonfile {
+        Some(f) => Some(test.datapath.join(f)),
+        None => None,
+    };
+
     setupfn(&test);
+
     let uuid = Uuid::parse_str(uuid).unwrap();
     let result = modify_command(
         &test,
@@ -572,8 +581,11 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
+        jsonfile,
     );
-    if assert_result(result, expect, "modify command").is_err() {
+
+    let testmsg = &format!("modify command testcase {}", testname);
+    if assert_result(result, expect, testmsg).is_err() {
         return;
     }
 
@@ -604,6 +616,7 @@ fn test_modify() {
         None,
         false,
         false,
+        None,
         |_| {},
     );
     test_modify_helper(
@@ -618,6 +631,7 @@ fn test_modify() {
         None,
         true,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -634,6 +648,7 @@ fn test_modify() {
         None,
         false,
         true,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -650,6 +665,7 @@ fn test_modify() {
         None,
         false,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -666,6 +682,7 @@ fn test_modify() {
         None,
         false,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -682,6 +699,7 @@ fn test_modify() {
         Some("added-attr-value".to_string()),
         false,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -698,6 +716,7 @@ fn test_modify() {
         Some("added-attr-value".to_string()),
         false,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -714,6 +733,7 @@ fn test_modify() {
         None,
         false,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },
@@ -730,6 +750,7 @@ fn test_modify() {
         None,
         true,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
             test.populate_defined_device(UUID, "0000:00:02.0", "defined.json");
@@ -747,6 +768,7 @@ fn test_modify() {
         None,
         true,
         false,
+        None,
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
             test.populate_defined_device(UUID, "0000:00:02.0", "defined.json");
@@ -764,6 +786,25 @@ fn test_modify() {
         None,
         true,
         true,
+        None,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+        },
+    );
+    // specifying via jsonfile properly
+    test_modify_helper(
+        "jsonfile",
+        Expect::Pass,
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
         },

--- a/tests/modify/jsonfile.expected
+++ b/tests/modify/jsonfile.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modified.json
+++ b/tests/modify/modified.json
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}


### PR DESCRIPTION
To allow updates of multiple attributes with a single mdevctl call adding the jsonfile optional parameter to command modify.

Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>