### PR TITLE
Fix panic on modify delattr with invalid index

### DIFF
--- a/src/mdev.rs
+++ b/src/mdev.rs
@@ -433,7 +433,7 @@ impl<'a> MDev<'a> {
         match index {
             Some(i) => {
                 let i: usize = i.try_into().unwrap();
-                if i > self.attrs.len() {
+                if i >= self.attrs.len() {
                     return Err(anyhow!("Attribute index {} is invalid", i));
                 }
                 self.attrs.remove(i);


### PR DESCRIPTION
Providing the maximum valid index plus one causes a panic on modify delattr command.

Here is an example:

$ mdevctl list -d -v
ed4654e5-12f2-4936-b079-4bba74d2c785 matrix vfio_ap-passthrough auto (active)
  Attrs:
    @{0}: {"testattr1":"testval1"}
    @{1}: {"testattr2":"testval2"}
    @{2}: {"testattr3":"testval3"}

$ mdevctl modify --delattr -i 3 -u ed4654e5-12f2-4936-b079-4bba74d2c785 thread 'main' panicked at 'removal index (is 3) should be < len (is 3)', src/mdev.rs:442:28 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>