### PR TITLE
Fix RC handling in callout_dir

### DIFF
--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -343,6 +343,7 @@ impl Callout {
 
         match rc {
             Some(0) => Ok(()),
+            Some(2) => Err(CalloutError::NoMatchingScript),
             Some(n) => Err(CalloutError::InvocationFailure(
                 self.script.as_ref().unwrap().to_path_buf(),
                 Some(n),


### PR DESCRIPTION
If callout script is set the special return code 2 which represent NoMatchingScript found needs to be added to the rc matching.

Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>