### PR TITLE
undefine: report error if device is not undefined

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -877,6 +877,29 @@ fn test_undefine() {
         Some(PARENT.to_string()),
         |_| {},
     );
+
+    // callout script always returns with RC=0
+    test_undefine_helper(
+        "single-callout-all-pass",
+        Expect::Pass,
+        UUID,
+        Some(PARENT.to_string()),
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh");
+        },
+    );
+    // callout script rejects in pre event undefine with RC=1
+    test_undefine_helper(
+        "single-callout-pre-fail",
+        Expect::Fail(None),
+        UUID,
+        Some(PARENT.to_string()),
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh");
+        },
+    );
 }
 
 fn test_start_command_callout<F>(


### PR DESCRIPTION
If a callout script returns with an error code the undefine method is not called and therefore the mdev is not undefined. The user should get notified this occured instead of silently suppressing the error when the mdev is not undefined.