### PR TITLE
Some test-related changes and other misc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ clap_complete = "3.0.6"
 uuid = "1.0"
 
 [dev-dependencies]
-nix = "0.24.0"
+nix = "0.26"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdevctl"
 # For now, just bump the y version on release (x.y.z)
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Jonathon Jongsma <jjongsma@redhat.com>"]
 edition = "2018"
 license = "LGPL-2.1"

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -71,7 +71,7 @@ impl Display for Event {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[allow(dead_code)]
 pub enum Action {
     Start,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -128,11 +128,9 @@ impl TestEnvironment {
          * in other threads. Copying executable files in a child process avoid this. */
         match unsafe { fork() }.expect("failed to fork") {
             ForkResult::Parent { child } => {
-                println!("parent");
                 waitpid(child, None).expect("Failed to wait for child");
             }
             ForkResult::Child => {
-                println!("child");
                 fs::copy(calloutscript, &dest).expect("Unable to copy callout script");
                 unsafe {
                     libc::_exit(0);

--- a/tests/modify/callout-fail-force.expected
+++ b/tests/modify/callout-fail-force.expected
@@ -1,0 +1,24 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    }
+  ]
+}

--- a/tests/modify/callout-pass.expected
+++ b/tests/modify/callout-pass.expected
@@ -1,0 +1,24 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    }
+  ]
+}


### PR DESCRIPTION
- Bump version to 1.3.0
- tests: make test failure reports more obvious
- tests: remove stray debug prints during fork
- tests: test 'stop' with callouts
- Bump 'nix' dependency
