### PR TITLE
undefine: add force option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,6 +84,12 @@ pub enum MdevctlCommands {
         uuid: Uuid,
         #[clap(short, long, help = "Parent of the device to be undefined")]
         parent: Option<String>,
+        #[clap(
+            short,
+            long,
+            help = "Override a decline by a callout script to undefine"
+        )]
+        force: bool,
     },
 
     #[clap(


### PR DESCRIPTION
The force option on command undefine allows to override the decision of a callout script to reject in the callout pre event the undefine.

Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>
Reviewed-by: Steffen Eiden <seiden@linux.ibm.com>