### PR TITLE
Callout version live v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 clap = { version = "3.1.18", features = ["derive"]}
 env_logger = "0.8.3"
 log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0", features = ["preserve_order"]}
 uuid = {version = "1.0", features = ["v4"]}
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.8.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0", features = ["preserve_order"]}
+serial_test = { version = "1.0.0" }
 uuid = {version = "1.0", features = ["v4"]}
 tempfile = "3"
 

--- a/mdevctl.rst
+++ b/mdevctl.rst
@@ -361,8 +361,8 @@ file for define, or activating a device for start).
 Essentially, the procedure in mdevctl looks like this:
 
     - command-line parsing & setup
+    - invoke live-command call-out (if live is requested)
     - invoke pre-command call-out
-    - invoke live-command call-out
     - primary command execution [1]_
     - invoke post-command call-out [1]_
     - invoke notifier

--- a/mdevctl.rst
+++ b/mdevctl.rst
@@ -468,6 +468,72 @@ the device type.
             }
         ]
 
+``Get-capabilities``
+
+    A get event is invoked on every new mdevctl execution to find a matching script
+    supporting versioning for the device type.
+    Event type is ``get``. Action is ``capabilities``. State is ``none``.
+    Note that, unlike other call-outs events, **get-capabilities provides a
+    versioning JSON on stdin, and a versioning JSON is returned via stdout**.
+    If a script is found the script is used for every event and action for the
+    device type. Should no script be found the none versioning pattern is used.
+
+    If a valid versioning JSON is returned on stdout and the return code is NOT 2
+    the script is a positive match for the provided device type. A script providing
+    versioning is the primary choice for a device type when mdevctl is executing
+    callouts.
+
+    A script is provided on standard in with a versioning JSON describing the mdevctl
+    supported version, actions and events. Example::
+
+        {
+          "provides": {
+            "version": "1.1.0",
+            "actions": [
+              "start",
+              "stop",
+              "define",
+              "undefine",
+              "modify",
+              "attributes",
+              "capabilities"
+            ],
+            "events": [
+              "pre",
+              "post",
+              "notify",
+              "get"
+            ]
+          }
+        }
+
+    A script that wants to support versioning must return a versioning JSON on standard
+    output. The script should list all supported actions in the actions array and all
+    supported events in the events array. It is possible to add additional actions or
+    events in the array but if mdevctl did not have these in the arrays in provides
+    they are ignored. Example::
+
+        {
+          "supports": {
+            "version": "1.1.0",
+            "actions": [
+              "start",
+              "stop",
+              "define",
+              "undefine",
+              "modify",
+              "attributes",
+              "capabilities"
+            ],
+            "events": [
+              "pre",
+              "post",
+              "notify",
+              "get"
+            ]
+          }
+        }
+
 AUTO-START CALL-OUTS
 --------------------
 

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -401,6 +401,18 @@ impl CalloutScripts {
                             match self.parse_script_output(res) {
                                 Ok(cv) => {
                                     debug!(" Script supports versioning: {:?}", cv);
+                                    if cv.has_action(Action::Unknown) {
+                                        warn!(
+                                            "Callout script {:?} provides unknown Action type",
+                                            path
+                                        );
+                                    }
+                                    if cv.has_event(Event::Unknown) {
+                                        warn!(
+                                            "Callout script {:?} provides unknown Event type",
+                                            path
+                                        );
+                                    }
                                     return Some((path, cv));
                                 }
                                 Err(CalloutError::InvalidJSON(e)) => {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -369,11 +369,8 @@ impl CalloutScripts {
 
     fn parse_script_output(&self, output: Output) -> Result<CalloutVersion, CalloutError> {
         let stdout = String::from_utf8(output.stdout).unwrap();
-        let ce: CalloutExchange =
-            match serde_json::from_str(&stdout).map_err(CalloutError::InvalidJSON) {
-                Ok(ce) => ce,
-                Err(e) => return Err(e),
-            };
+        let ce: CalloutExchange = 
+            serde_json::from_str(&stdout).map_err(CalloutError::InvalidJSON)?;
         ce.supports.ok_or(CalloutError::NoSupportedVersion)
     }
 

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -535,7 +535,6 @@ impl Callout {
         }
     }
 
-    #[allow(dead_code)]
     pub fn invoke_modify_live(dev: &mut MDev) -> Result<()> {
         let mut c = Callout::new();
 

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -257,11 +257,23 @@ fn find_callout_script(dev: &mut MDev) -> Result<CalloutScript, CalloutError> {
     return CALLOUT_SCRIPTS.lock().unwrap().find_script(dev);
 }
 
+// For testing purposes a reset is required
+#[cfg(test)]
+pub fn reset_callout_scripts() {
+    return CALLOUT_SCRIPTS.lock().unwrap().reset();
+}
+
 impl CalloutScripts {
     pub const fn new() -> Self {
         CalloutScripts {
             callouts: Vec::new(),
         }
+    }
+
+    // For testing purposes a reset is required
+    #[cfg(test)]
+    fn reset(&mut self) {
+        self.callouts.clear();
     }
 
     fn find_script(&mut self, dev: &mut MDev) -> Result<CalloutScript, CalloutError> {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -26,7 +26,7 @@ enum CalloutError {
 impl Display for CalloutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CalloutError::NoMatchingScript => write!(f, "No matching script for device"),
+            CalloutError::NoMatchingScript => write!(f, "No matching script for device found"),
             CalloutError::InvocationFailure(p, i) => write!(
                 f,
                 "Script '{:?}' failed with status '{}'",

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -55,18 +55,10 @@ impl std::error::Error for CalloutError {
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Event::Pre => {
-                write!(f, "pre")
-            }
-            Event::Post => {
-                write!(f, "post")
-            }
-            Event::Notify => {
-                write!(f, "notify")
-            }
-            Event::Get => {
-                write!(f, "get")
-            }
+            Event::Pre => write!(f, "pre"),
+            Event::Post => write!(f, "post"),
+            Event::Notify => write!(f, "notify"),
+            Event::Get => write!(f, "get"),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,6 +156,15 @@ pub enum MdevctlCommands {
         )]
         manual: bool,
         #[clap(
+            short,
+            long,
+            conflicts_with_all(&["type", "addattr", "delattr", "index", "value", "auto", "manual"]),
+            help = "Modify the running device definition only unless used together with defined option"
+        )]
+        live: bool,
+        #[clap(short, long, help = "Modify the stored device definition")]
+        defined: bool,
+        #[clap(
             long, value_parser,
             conflicts_with_all(&["type", "addattr", "delattr", "index", "value", "auto", "manual"]),
             help = "Specify device details in JSON format"

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,30 @@ fn undefine_command(
     Ok(())
 }
 
+fn dev_from_jsonfile(
+    env: &dyn Environment,
+    uuid: Uuid,
+    parent: Option<String>,
+    jsonfile: Option<PathBuf>,
+) -> Result<Option<MDev>, anyhow::Error> {
+    match jsonfile {
+        Some(jsonfile) => {
+            let _ = std::fs::File::open(&jsonfile)
+                .with_context(|| format!("Unable to read file {:?}", jsonfile));
+            let parent = parent
+                .ok_or_else(|| anyhow!("Parent device required to modify device via json file"))?;
+            let filecontents = fs::read_to_string(&jsonfile)
+                .with_context(|| format!("Unable to read jsonfile {:?}", jsonfile))?;
+            let jsonval = serde_json::from_str(&filecontents)?;
+
+            let mut d = MDev::new(env, uuid);
+            d.load_from_json(parent, &jsonval)?;
+            Ok(Some(d))
+        }
+        _ => Ok(None),
+    }
+}
+
 /// Implementation of the `mdevctl modify` command
 #[allow(clippy::too_many_arguments)]
 fn modify_command(
@@ -208,16 +232,10 @@ fn modify_command(
 ) -> Result<()> {
     let mut dev = get_defined_device(env, uuid, parent.as_ref())?;
 
-    if let Some(jsonfile) = jsonfile {
-        let _ = std::fs::File::open(&jsonfile)
-            .with_context(|| format!("Unable to read file {:?}", jsonfile));
-
-        let mut d = MDev::new(env, uuid);
-        let filecontents = fs::read_to_string(&jsonfile)
-            .with_context(|| format!("Unable to read jsonfile {:?}", jsonfile))?;
-        let jsonval = serde_json::from_str(&filecontents)?;
-        d.load_from_json(dev.parent().unwrap().to_string(), &jsonval)?;
-        dev = d;
+    if jsonfile.is_some() {
+        if let Some(json_dev) = dev_from_jsonfile(env, uuid, parent.clone(), jsonfile)? {
+            dev = json_dev;
+        }
     } else {
         if mdev_type.is_some() {
             dev.mdev_type = mdev_type;

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,6 +491,75 @@ fn defined_devices<'a>(
     Ok(devices)
 }
 
+/// Get a map of all active devices, optionally filtered by uuid and parent
+fn active_devices<'a>(
+    env: &'a dyn Environment,
+    uuid: Option<&Uuid>,
+    parent: Option<&String>,
+) -> Result<BTreeMap<String, Vec<MDev<'a>>>> {
+    let mut devices: BTreeMap<String, Vec<MDev>> = BTreeMap::new();
+    debug!(
+        "Looking up active mdevs: uuid={:?}, parent={:?}",
+        uuid, parent
+    );
+    if let Ok(dir) = env.mdev_base().read_dir() {
+        for deve in dir {
+            let deve = deve?;
+            let fname = deve.file_name();
+            let basename = fname.to_str().unwrap();
+            debug!("found defined mdev {}", basename);
+            let u = Uuid::parse_str(basename);
+
+            if u.is_err() {
+                warn!("Can't determine uuid for file '{}'", basename);
+                continue;
+            }
+            let u = u.unwrap();
+
+            if uuid.is_some() && uuid != Some(&u) {
+                debug!(
+                    "Ignoring device {} because it doesn't match uuid {}",
+                    u,
+                    uuid.unwrap()
+                );
+                continue;
+            }
+
+            let mut dev = MDev::new(env, u);
+            if dev.load_from_sysfs().is_ok() {
+                if parent.is_some() && (parent != dev.parent.as_ref()) {
+                    debug!(
+                        "Ignoring device {} because it doesn't match parent {}",
+                        dev.uuid,
+                        parent.as_ref().unwrap()
+                    );
+                    continue;
+                }
+
+                let _ = dev.load_definition();
+
+                // don't show attributes from the persistent definition if we're listing
+                // active mdevs. The definition may have changed since the mdev was started
+                dev.attrs.clear();
+
+                // if the device is supported by a callout script that gets attributes, show
+                // those in the output
+                if let Ok(attrs) = Callout::get_attributes(&mut dev) {
+                    let _ = dev.add_attributes(&attrs);
+                }
+
+                let devparent = dev.parent()?;
+                if !devices.contains_key(devparent) {
+                    devices.insert(devparent.clone(), Vec::new());
+                };
+
+                devices.get_mut(devparent).unwrap().push(dev);
+            };
+        }
+    }
+    Ok(devices)
+}
+
 /// Implementation of the `mdevctl list` command
 fn list_command(
     env: &dyn Environment,
@@ -514,66 +583,11 @@ fn list_command_helper(
     uuid: Option<Uuid>,
     parent: Option<String>,
 ) -> Result<String> {
-    let mut devices: BTreeMap<String, Vec<MDev>> = BTreeMap::new();
+    let mut devices: BTreeMap<String, Vec<MDev>>;
     if defined {
         devices = defined_devices(env, uuid.as_ref(), parent.as_ref())?;
     } else {
-        debug!("Looking up active mdevs");
-        if let Ok(dir) = env.mdev_base().read_dir() {
-            for dev in dir {
-                let dev = dev?;
-                let fname = dev.file_name();
-                let basename = fname.to_str().unwrap();
-                debug!("found defined mdev {}", basename);
-                let u = Uuid::parse_str(basename);
-
-                if u.is_err() {
-                    warn!("Can't determine uuid for file '{}'", basename);
-                    continue;
-                }
-                let u = u.unwrap();
-
-                if uuid.is_some() && uuid != Some(u) {
-                    debug!(
-                        "Ignoring device {} because it doesn't match uuid {}",
-                        u,
-                        uuid.unwrap()
-                    );
-                    continue;
-                }
-
-                let mut dev = MDev::new(env, u);
-                if dev.load_from_sysfs().is_ok() {
-                    if parent.is_some() && (parent != dev.parent) {
-                        debug!(
-                            "Ignoring device {} because it doesn't match parent {}",
-                            dev.uuid,
-                            parent.as_ref().unwrap()
-                        );
-                        continue;
-                    }
-
-                    let _ = dev.load_definition();
-
-                    // don't show attributes from the persistent definition if we're listing
-                    // active mdevs. The definition may have changed since the mdev was started
-                    dev.attrs.clear();
-
-                    // if the device is supported by a callout script that gets attributes, show
-                    // those in the output
-                    if let Ok(attrs) = Callout::get_attributes(&mut dev) {
-                        let _ = dev.add_attributes(&attrs);
-                    }
-
-                    let devparent = dev.parent()?;
-                    if !devices.contains_key(devparent) {
-                        devices.insert(devparent.clone(), Vec::new());
-                    };
-
-                    devices.get_mut(devparent).unwrap().push(dev);
-                };
-            }
-        }
+        devices = active_devices(env, uuid.as_ref(), parent.as_ref())?;
     }
 
     // ensure that devices are sorted in a stable order

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,28 +227,71 @@ fn modify_command(
     value: Option<String>,
     auto: bool,
     manual: bool,
+    live: bool,
+    defined: bool,
     jsonfile: Option<PathBuf>,
     force: bool,
 ) -> Result<()> {
-    let mut dev = get_defined_device(env, uuid, parent.as_ref())?;
-
-    if jsonfile.is_some() {
-        if let Some(json_dev) = dev_from_jsonfile(env, uuid, parent.clone(), jsonfile)? {
-            dev = json_dev;
-        }
-    } else {
+    debug!("Modifying mdev {:?}", uuid);
+    if live {
         if mdev_type.is_some() {
-            dev.mdev_type = mdev_type;
+            return Err(anyhow!("'type' cannot be changed on active mdev"));
         }
-
-        if auto && manual {
-            return Err(anyhow!("'auto' and 'manual' are mutually exclusive"));
-        }
-
         if auto {
-            dev.autostart = true;
-        } else if manual {
-            dev.autostart = false;
+            return Err(anyhow!("'auto' cannot be changed on active mdev"));
+        }
+        if manual {
+            return Err(anyhow!("'manual' cannot be changed on active mdev"));
+        }
+        let mut act_dev = get_active_device(env, uuid, parent.as_ref())?;
+        if let Some(json_dev) = dev_from_jsonfile(env, uuid, act_dev.parent.clone(), jsonfile)? {
+            if json_dev.mdev_type != act_dev.mdev_type {
+                return Err(anyhow!("'type' cannot be changed on active mdev"));
+            }
+            if json_dev.parent != act_dev.parent {
+                return Err(anyhow!("'parent' cannot be changed on active mdev"));
+            }
+            act_dev = json_dev;
+        } else {
+            return Err(anyhow!("'jsonfile' option must be used with 'live' option"));
+        }
+
+        if defined {
+            // live and stored modify - defined dev config exists and types match
+            let def_dev = get_defined_device(env, uuid, act_dev.parent.as_ref())?;
+            if def_dev.mdev_type != act_dev.mdev_type {
+                return Err(anyhow!("'type' of active and defined mdev does not match"));
+            }
+
+            return Callout::invoke_modify_live(&mut act_dev).and_then(|_| {
+                Callout::invoke(&mut act_dev, Action::Modify, force, |dev| {
+                    dev.write_config()
+                })
+            });
+        }
+        // live modify only
+        Callout::invoke_modify_live(&mut act_dev)
+    } else {
+        let mut dev: MDev;
+        // stored configuration modify
+        match dev_from_jsonfile(env, uuid, parent.clone(), jsonfile)? {
+            Some(dev_json) => {
+                dev = dev_json;
+            }
+            None => {
+                dev = get_defined_device(env, uuid, parent.as_ref())?;
+                if mdev_type.is_some() {
+                    dev.mdev_type = mdev_type;
+                }
+                if auto && manual {
+                    return Err(anyhow!("'auto' and 'manual' are mutually exclusive"));
+                }
+                if auto {
+                    dev.autostart = true;
+                } else if manual {
+                    dev.autostart = false;
+                }
+            }
         }
 
         match addattr {
@@ -262,9 +305,8 @@ fn modify_command(
                 }
             }
         }
+        Callout::invoke(&mut dev, Action::Modify, force, |dev| dev.write_config())
     }
-
-    Callout::invoke(&mut dev, Action::Modify, force, |dev| dev.write_config())
 }
 
 /// convert 'start' command arguments into a MDev struct
@@ -507,6 +549,43 @@ fn defined_devices<'a>(
         }
     }
     Ok(devices)
+}
+
+/// convenience function to lookup an active device by uuid and parent
+fn get_active_device<'a>(
+    env: &'a dyn Environment,
+    uuid: Uuid,
+    parent: Option<&String>,
+) -> Result<MDev<'a>> {
+    let devs = active_devices(env, Some(&uuid), parent)?;
+    if devs.is_empty() {
+        match parent {
+            None => Err(anyhow!(
+                "Mediated device {} is not active",
+                uuid.hyphenated().to_string()
+            )),
+            Some(p) => Err(anyhow!(
+                "Mediated device {}/{} is not active",
+                p,
+                uuid.hyphenated().to_string()
+            )),
+        }
+    } else if devs.len() > 1 {
+        Err(anyhow!(
+            "Multiple parents found for {}. System error?",
+            uuid.hyphenated().to_string()
+        ))
+    } else {
+        let (parent, children) = devs.iter().next().unwrap();
+        if children.len() > 1 {
+            return Err(anyhow!(
+                "Multiple definitions found for {}/{}",
+                parent,
+                uuid.hyphenated().to_string()
+            ));
+        }
+        Ok(children.get(0).unwrap().clone())
+    }
 }
 
 /// Get a map of all active devices, optionally filtered by uuid and parent
@@ -850,11 +929,13 @@ fn main() -> Result<()> {
                 value,
                 auto,
                 manual,
+                live,
+                defined,
                 jsonfile,
                 force,
             } => modify_command(
-                &env, uuid, parent, mdev_type, addattr, delattr, index, value, auto, manual,
-                jsonfile, force,
+                &env, uuid, parent, mdev_type, addattr, delattr, index, value, auto, manual, live,
+                defined, jsonfile, force,
             ),
             MdevctlCommands::Start {
                 uuid,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -569,6 +569,67 @@ fn test_define() {
             test.populate_callout_script("rc1.sh");
         },
     );
+
+    // test define with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    test_define_command_callout(
+        "define-with-version-callout-all-pass",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-all-fail",
+        Expect::Fail(None),
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_modify_helper<F>(
@@ -913,6 +974,108 @@ fn test_modify() {
             test.populate_callout_script("rc1.sh");
         },
     );
+
+    // test modify with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_undefine_helper<F>(
@@ -1028,6 +1191,68 @@ fn test_undefine() {
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
             test.populate_callout_script("rc1.sh");
+        },
+    );
+
+    // test define with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_undefine_helper(
+        "undefine-single-with-version-callout-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "undefine-single-with-version-callout-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
         },
     );
 }
@@ -1380,6 +1605,78 @@ fn test_start() {
     // TODO: test attributes -- difficult because executing the 'start' command by writing to
     // the 'create' file in sysfs does not automatically create the device file structure in
     // the temporary test environment, so writing the sysfs attribute files fails.
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_start_command_callout(
+        "start-single-with-version-callout-pass",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-single-with-version-callout-fail",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_stop_helper<F>(testname: &str, expect: Expect, uuid: &str, force: bool, setupfn: F)
@@ -1423,6 +1720,52 @@ fn test_stop() {
         t.populate_active_device(UUID, PARENT, MDEV_TYPE);
         t.populate_callout_script("rc1.sh")
     });
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_stop_helper(
+        "stop-single-callout-with-version-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callout-with-version-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("ver-rc1.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callouts-mix-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callouts-mix-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning
+        },
+    );
 }
 
 #[test]
@@ -2050,6 +2393,191 @@ fn test_callouts() {
         |test| {
             test.populate_callout_script_full("rc2.sh", None, true);
             test.populate_callout_script_full("rc0.sh", None, false);
+        },
+    );
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    const UUID_VER_RC1: &str = "11111111-1111-0000-0000-111111111111";
+    const UUID_VER_RC2: &str = "11111111-1111-0000-0000-222222222222";
+    const UUID_VER_BAD_JSON: &str = "11111111-1111-0000-0000-aaaaaaaaaaaa";
+    const UUID_VER_ACTION_DUMMY: &str = "11111111-1111-0000-0000-bbbbbbbbbbbb";
+    const UUID_VER_EVENT_DUMMY: &str = "11111111-1111-0000-0000-cccccccccccc";
+    const UUID_VER_MODIFY_MISSING: &str = "11111111-1111-0000-0000-dddddddddddd";
+    const UUID_VER_PROVIDES: &str = "11111111-1111-0000-0000-eeeeeeeeeeee";
+    const UUID_VER_INVALID_JSON: &str = "11111111-1111-0000-0000-ffffffffffff";
+
+    test_invoke_callout(
+        "test_callout_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_mix_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_mix_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_get_callout(
+        "test_callout_with_version_good_json",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_get_callout(
+        "test_callout_with_version_bad_json",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0-get-attr-bad-json.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_get_capabilities_rc1_run_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_RC1).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_get_capabilities_rc2_run_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_RC2).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_get_capabilities_bad_run_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_BAD_JSON).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_unknown_action_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_ACTION_DUMMY).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_unknown_event_with_verion_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_EVENT_DUMMY).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_missing_modify_run_start_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_MODIFY_MISSING).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_missing_modify_run_modify_fail",
+        Expect::Fail(None),
+        Action::Modify,
+        Uuid::parse_str(UUID_VER_MODIFY_MISSING).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_json_provides_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_PROVIDES).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_json_invalid_with_version_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_INVALID_JSON).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
         },
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -64,6 +64,7 @@ impl TestEnvironment {
             fs::create_dir_all(&dir)
                 .expect(format!("Unable to create notification_dir '{:?}'", &dir).as_str());
         }
+        reset_callout_scripts();
         info!("---- Running test '{}/{}' ----", testname, testcase);
         test
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use log::info;
 use nix::sys::wait::waitpid;
 use nix::unistd::{fork, ForkResult};
+use serial_test::serial;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
@@ -369,6 +370,7 @@ fn test_define_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_define() {
     init();
 
@@ -627,6 +629,7 @@ fn test_modify_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_modify() {
     init();
 
@@ -937,6 +940,7 @@ fn test_undefine_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_undefine() {
     init();
 
@@ -1089,6 +1093,7 @@ fn test_start_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_start() {
     init();
 
@@ -1394,6 +1399,7 @@ where
 }
 
 #[test]
+#[serial]
 fn test_stop() {
     init();
 
@@ -1419,6 +1425,7 @@ fn test_stop() {
 }
 
 #[test]
+#[serial]
 fn test_invalid_files() {
     init();
 
@@ -1466,6 +1473,7 @@ fn test_list_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_list() {
     init();
 
@@ -1707,6 +1715,7 @@ fn test_types_helper(
 }
 
 #[test]
+#[serial]
 fn test_types() {
     init();
 
@@ -1821,6 +1830,7 @@ fn test_get_callout<F>(
 }
 
 #[test]
+#[serial]
 fn test_callouts() {
     init();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -673,6 +673,8 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
+        false,
+        false,
         jsonfile,
         force,
     );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -644,6 +644,8 @@ fn test_modify_helper<F>(
     value: Option<String>,
     auto: bool,
     manual: bool,
+    live: bool,
+    defined: bool,
     jsonfile: Option<PathBuf>,
     force: bool,
     setupfn: F,
@@ -673,8 +675,8 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
-        false,
-        false,
+        live,
+        defined,
         jsonfile,
         force,
     );
@@ -690,6 +692,81 @@ fn test_modify_helper<F>(
     assert!(def.is_defined());
     let filecontents = fs::read_to_string(&path).unwrap();
     test.compare_to_file(&format!("{}.expected", testname), &filecontents);
+}
+
+fn test_modify_defined_active_helper<F>(
+    testname: &str,
+    expect: Expect,
+    uuid: &str,
+    parent: Option<String>,
+    mdev_type: Option<String>,
+    addattr: Option<String>,
+    delattr: bool,
+    index: Option<u32>,
+    value: Option<String>,
+    auto: bool,
+    manual: bool,
+    live: bool,
+    defined: bool,
+    jsonfile: Option<PathBuf>,
+    force: bool,
+    setupfn: F,
+) where
+    F: Fn(&TestEnvironment),
+{
+    use crate::modify_command;
+    let test = TestEnvironment::new("modify", testname);
+
+    // load the jsonfile from the test path.
+    let jsonfile = match jsonfile {
+        Some(f) => Some(test.datapath.join(f)),
+        None => None,
+    };
+
+    setupfn(&test);
+
+    let uuid = Uuid::parse_str(uuid).unwrap();
+    let result = modify_command(
+        &test,
+        uuid,
+        parent.clone(),
+        mdev_type,
+        addattr,
+        delattr,
+        index,
+        value,
+        auto,
+        manual,
+        live,
+        defined,
+        jsonfile,
+        force,
+    );
+    if test
+        .assert_result(result, expect, Some("modify command"))
+        .is_err()
+    {
+        return;
+    }
+
+    let def_active = crate::get_active_device(&test, uuid, parent.as_ref())
+        .expect("Couldn't find defined device");
+    assert!(def_active.active);
+    let def_json = serde_json::to_string_pretty(
+        &def_active
+            .to_json(false)
+            .expect("Couldn't get json from active device"),
+    )
+    .expect("Couldn't get json from active device");
+    test.compare_to_file(&format!("{}.active.expected", testname), &def_json);
+
+    let def = crate::get_defined_device(&test, uuid, parent.as_ref())
+        .expect("Couldn't find defined device");
+    let path = def.persist_path().unwrap();
+    assert!(path.exists());
+    assert!(def.is_defined());
+    let filecontents = fs::read_to_string(&path).unwrap();
+    test.compare_to_file(&format!("{}.defined.expected", testname), &filecontents);
 }
 
 #[test]
@@ -711,6 +788,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         None,
         false,
         |_| {},
@@ -726,6 +805,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         false,
@@ -745,6 +826,8 @@ fn test_modify() {
         None,
         false,
         true,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -761,6 +844,8 @@ fn test_modify() {
         true,
         Some(2),
         None,
+        false,
+        false,
         false,
         false,
         None,
@@ -781,6 +866,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -797,6 +884,8 @@ fn test_modify() {
         false,
         Some(3),
         Some("added-attr-value".to_string()),
+        false,
+        false,
         false,
         false,
         None,
@@ -817,6 +906,8 @@ fn test_modify() {
         Some("added-attr-value".to_string()),
         false,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -833,6 +924,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         None,
@@ -853,6 +946,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -871,6 +966,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         false,
@@ -891,6 +988,8 @@ fn test_modify() {
         None,
         true,
         true,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -908,6 +1007,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         Some(PathBuf::from("modified.json")),
@@ -929,6 +1030,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -949,6 +1052,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -968,6 +1073,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         true,
@@ -992,6 +1099,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1011,6 +1120,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1028,6 +1139,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         Some(PathBuf::from("modified.json")),
@@ -1050,6 +1163,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1070,12 +1185,200 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
             test.populate_defined_device(UUID_VER, PARENT, "defined.json");
             test.populate_callout_script("rc0.sh"); // no versioning
             test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_NO_LIVE: &str = "11111111-1111-0000-0000-000000000000";
+    const UUID_LIVE: &str = "11111111-1111-1111-0000-000000000000";
+
+    test_modify_helper(
+        "live-event-supported",
+        Expect::Pass,
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-event-unsupported-by-callout",
+        Expect::Fail(None),
+        UUID_NO_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_NO_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_NO_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-unsupported-script-without-version-support",
+        Expect::Fail(Some(
+            format!("'jsonfile' option must be used with 'live' option").as_str(),
+        )),
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_active_device(UUID, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-supported-but-fails",
+        Expect::Fail(None),
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc1.sh");
+        },
+    );
+    test_modify_helper(
+        "live-fail-without-jsonfile",
+        Expect::Fail(Some(
+            format!("'jsonfile' option must be used with 'live' option").as_str(),
+        )),
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+
+    test_modify_defined_active_helper(
+        "live-defined-supported",
+        Expect::Pass,
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        true,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
+        },
+    );
+    test_modify_defined_active_helper(
+        "live-defined-live-event-unsupported",
+        Expect::Fail(None),
+        UUID_NO_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        true,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_NO_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_NO_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
+        },
+    );
+    test_modify_defined_active_helper(
+        "defined-only",
+        Expect::Pass,
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        Some("added-attr".to_string()),
+        false,
+        None,
+        Some("added-attr-value".to_string()),
+        false,
+        false,
+        false,
+        true,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_active_device(UUID, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
         },
     );
 }

--- a/tests/callouts/live-rc0.sh
+++ b/tests/callouts/live-rc0.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 1.1.0 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 1.1.1 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.1\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            *)
+                exit 0
+            ;;
+        esac
+    ;;
+    live)
+        exit 0
+    ;;
+    *)
+        exit 0
+    ;;
+esac

--- a/tests/callouts/live-rc1.sh
+++ b/tests/callouts/live-rc1.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 1.1.0 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 1.1.1 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.1\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            *)
+                exit 0
+            ;;
+        esac
+    ;;
+    live)
+        exit 1
+    ;;
+    *)
+        exit 0
+    ;;
+esac

--- a/tests/callouts/modify-active.sh
+++ b/tests/callouts/modify-active.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+tempfile="tmp_modify-live.json"
+
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 1.1.0 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 1.1.1 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.1\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    pre)
+        case "$action" in
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                if [ -f "$tempfile" ]; then
+                    cat $tempfile
+                rm $tempfile
+                else
+                        echo "[]"
+                fi
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    live)
+        case "$action" in
+            modify)
+                echo "$json" | grep -oP '"attrs":+\K(\[.*\])' > $tempfile
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/ver-rc0-get-attr-bad-json.sh
+++ b/tests/callouts/ver-rc0-get-attr-bad-json.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 1.1.0 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-222222222222)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":\"a.b.c\","
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "not json"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac
+

--- a/tests/callouts/ver-rc0.sh
+++ b/tests/callouts/ver-rc0.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 1.1.0 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-222222222222)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":\"a.b.c\","
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "[{\"attribute0\": \"VALUE\"}]"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    pre)
+        case "$action" in
+            define)
+                exit 0
+            ;;
+            undefine)
+                exit 0
+            ;;
+            start)
+                exit 0
+            ;;
+            stop)
+                exit 0
+            ;;
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    post)
+        case "$action" in
+            define)
+                exit 0
+            ;;
+            undefine)
+                exit 0
+            ;;
+            start)
+                exit 0
+            ;;
+            stop)
+                exit 0
+            ;;
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac
+

--- a/tests/callouts/ver-rc1.sh
+++ b/tests/callouts/ver-rc1.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(</dev/stdin)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 1.1.0 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":\"1.1.0\","
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":\"a.b.c\","
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "[{\"attribute0\": \"VALUE\"}]"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac
+

--- a/tests/modify/defined-only.active.expected
+++ b/tests/modify/defined-only.active.expected
@@ -1,0 +1,5 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": []
+}

--- a/tests/modify/defined-only.defined.expected
+++ b/tests/modify/defined-only.defined.expected
@@ -1,0 +1,27 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    },
+    {
+      "added-attr": "added-attr-value"
+    }
+  ]
+}

--- a/tests/modify/live-defined-supported.active.expected
+++ b/tests/modify/live-defined-supported.active.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/live-defined-supported.defined.expected
+++ b/tests/modify/live-defined-supported.defined.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/live-event-supported.expected
+++ b/tests/modify/live-event-supported.expected
@@ -1,0 +1,24 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-all-pass.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-all-pass.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass2.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass2.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}


### PR DESCRIPTION
This series implements versioning in the callout script API. The versioning allows to add the new callout event `live` which allows callout scripts to support live modifications of an started mdev device.