### PR TITLE
trim trailing null from callout script get-attributes output

### DIFF
--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -187,7 +187,8 @@ impl Callout {
                         st = "[]".to_string();
                     }
 
-                    serde_json::from_str(&st).map_err(CalloutError::InvalidJSON)
+                    serde_json::from_str(st.trim_end_matches('\0'))
+                        .map_err(CalloutError::InvalidJSON)
                 } else {
                     c.print_err(&output, &path);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2041,4 +2041,14 @@ fn test_callouts() {
             test.populate_callout_script_full("rc0.sh", None, false);
         },
     );
+    test_get_callout(
+        "test_callout_good_json_null",
+        Expect::Pass,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("good-json-null-terminated.sh");
+        },
+    );
 }

--- a/tests/callouts/good-json-null-terminated.sh
+++ b/tests/callouts/good-json-null-terminated.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo -ne "[{\"attribute0\": \"VALUE\"}]\0"


### PR DESCRIPTION
A trailing null will make serde_json::from_str fail. Let's trim the string if a null is present to make it happy.

Fixes #84

Note, this will create a merge conflict in PR #83. If this change is acceptable, I can either rebase Boris' patches on top of this, or I can fit this patch in nicely after the conflicting commit.