### PR TITLE
Refactor get attributes

### DIFF
--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use log::{debug, warn};
 use std::ffi::OsStr;
 use std::fmt::{self, Display, Formatter};
@@ -14,6 +14,17 @@ pub enum Event {
     Post,
     Notify,
     Get,
+}
+
+fn invocation_failure(path: &PathBuf, code: Option<i32>) -> anyhow::Error {
+    anyhow!(
+        "Script '{:?}' failed with status '{}'",
+        path,
+        match code {
+            Some(i) => i.to_string(),
+            None => "unknown".to_string(),
+        }
+    )
 }
 
 #[derive(Debug)]
@@ -332,16 +343,13 @@ impl Callout {
     }
 
     fn callout(&mut self, dev: &mut MDev, event: Event, action: Action) -> Result<()> {
-        let res = match self.script {
+        match self.script {
             Some(ref s) => {
                 let output = self.invoke_script(dev, s, event, action)?;
                 self.print_err(&output, s);
                 match output.status.code() {
                     None | Some(0) => Ok(()),
-                    Some(n) => Err(CalloutError::InvocationFailure(
-                        self.script.as_ref().unwrap().to_path_buf(),
-                        Some(n),
-                    )),
+                    Some(n) => Err(invocation_failure(self.script.as_ref().unwrap(), Some(n))),
                 }
             }
             None => {
@@ -350,30 +358,25 @@ impl Callout {
                     if !dir.is_dir() {
                         continue;
                     }
-                    let r = match self
-                        .invoke_first_matching_script(dev, dir, event, action)
-                        .and_then(|(path, output)| {
-                            self.print_err(&output, &path);
-                            self.script = Some(path);
-                            output.status.code()
-                        }) {
-                        Some(0) => Ok(()),
-                        Some(n) => Err(CalloutError::InvocationFailure(
-                            self.script.as_ref().unwrap().to_path_buf(),
-                            Some(n),
-                        )),
-                        None => Err(CalloutError::NoMatchingScript),
+                    let r = match self.invoke_first_matching_script(dev, dir, event, action) {
+                        Some((p, o)) => {
+                            self.print_err(&o, &p);
+                            self.script = Some(p.clone());
+                            match o.status.code() {
+                                Some(0) => Ok(()),
+                                Some(n) => Err(invocation_failure(&p, Some(n))),
+                                None => continue,
+                            }
+                        }
+                        None => continue,
                     };
 
-                    if !matches!(r, Err(CalloutError::NoMatchingScript)) {
-                        res = r;
-                        break;
-                    }
+                    res = r;
+                    break;
                 }
                 res
             }
-        };
-        return res.map_err(anyhow::Error::from);
+        }
     }
 
     fn notify(&mut self, dev: &mut MDev, action: Action) {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -338,26 +338,16 @@ impl Callout {
         action: Action,
         dir: PathBuf,
     ) -> Result<(), CalloutError> {
-        let rc = match self.script {
-            Some(ref s) => self
-                .invoke_script(dev, s, event, action)
-                .ok()
-                .and_then(|output| {
-                    self.print_err(&output, s);
-                    output.status.code()
-                }),
-            _ => {
-                if !dir.is_dir() {
-                    return Err(CalloutError::NoMatchingScript);
-                }
-                self.invoke_first_matching_script(dev, dir, event, action)
-                    .and_then(|(path, output)| {
-                        self.print_err(&output, &path);
-                        self.script = Some(path);
-                        output.status.code()
-                    })
-            }
-        };
+        if !dir.is_dir() {
+            return Err(CalloutError::NoMatchingScript);
+        }
+        let rc = self
+            .invoke_first_matching_script(dev, dir, event, action)
+            .and_then(|(path, output)| {
+                self.print_err(&output, &path);
+                self.script = Some(path);
+                output.status.code()
+            });
 
         match rc {
             Some(0) => Ok(()),
@@ -370,16 +360,32 @@ impl Callout {
     }
 
     fn callout(&mut self, dev: &mut MDev, event: Event, action: Action) -> Result<()> {
-        for dir in dev.env.callout_dirs() {
-            let res = self.callout_dir(dev, event, action, dir);
-
-            if let Err(CalloutError::NoMatchingScript) = res {
-                continue;
+        let res = match self.script {
+            Some(ref s) => {
+                let output = self.invoke_script(dev, s, event, action)?;
+                self.print_err(&output, s);
+                match output.status.code() {
+                    None | Some(0) => Ok(()),
+                    Some(n) => Err(CalloutError::InvocationFailure(
+                        self.script.as_ref().unwrap().to_path_buf(),
+                        Some(n),
+                    )),
+                }
             }
+            None => {
+                let mut res = Ok(());
+                for dir in dev.env.callout_dirs() {
+                    let r = self.callout_dir(dev, event, action, dir);
 
-            return res.map_err(anyhow::Error::from);
-        }
-        Ok(())
+                    if !matches!(r, Err(CalloutError::NoMatchingScript)) {
+                        res = r;
+                        break;
+                    }
+                }
+                res
+            }
+        };
+        return res.map_err(anyhow::Error::from);
     }
 
     fn notify(&mut self, dev: &mut MDev, action: Action) {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -108,7 +108,7 @@ impl Callout {
 
     pub fn invoke<F>(&mut self, dev: &mut MDev, action: Action, force: bool, func: F) -> Result<()>
     where
-        F: Fn(&mut MDev) -> Result<()>,
+        F: Fn(&mut Self, &mut MDev) -> Result<()>,
     {
         let res = self
             .callout(dev, Event::Pre, action)
@@ -124,7 +124,7 @@ impl Callout {
                     .ok_or(e)
             })
             .and_then(|_| {
-                let tmp_res = func(dev);
+                let tmp_res = func(self, dev);
                 self.state = match tmp_res {
                     Ok(_) => State::Success,
                     Err(_) => State::Failure,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1789,13 +1789,13 @@ fn test_invoke_callout<F>(
     empty_mdev.parent = Some(parent.to_string());
 
     let mut callout = callout();
-    let res = callout.invoke(&mut empty_mdev, action, false, |_empty_mdev| Ok(()));
+    let res = callout.invoke(&mut empty_mdev, action, false, |_, _| Ok(()));
     let try_force = res.is_err();
     let _ = test.assert_result(res, expect, Some("non-forced"));
 
     // now force and ensure it succeeds
     if try_force {
-        let res = callout.invoke(&mut empty_mdev, action, true, |_empty_mdev| Ok(()));
+        let res = callout.invoke(&mut empty_mdev, action, true, |_, _| Ok(()));
         let _ = test.assert_result(res, Expect::Pass, Some("forced"));
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1788,13 +1788,14 @@ fn test_invoke_callout<F>(
     empty_mdev.mdev_type = Some(mdev_type.to_string());
     empty_mdev.parent = Some(parent.to_string());
 
-    let res = Callout::invoke(&mut empty_mdev, action, false, |_empty_mdev| Ok(()));
+    let mut callout = callout();
+    let res = callout.invoke(&mut empty_mdev, action, false, |_empty_mdev| Ok(()));
     let try_force = res.is_err();
     let _ = test.assert_result(res, expect, Some("non-forced"));
 
     // now force and ensure it succeeds
     if try_force {
-        let res = Callout::invoke(&mut empty_mdev, action, true, |_empty_mdev| Ok(()));
+        let res = callout.invoke(&mut empty_mdev, action, true, |_empty_mdev| Ok(()));
         let _ = test.assert_result(res, Expect::Pass, Some("forced"));
     }
 }
@@ -1816,7 +1817,7 @@ fn test_get_callout<F>(
     empty_mdev.mdev_type = Some(mdev_type.to_string());
     empty_mdev.parent = Some(parent.to_string());
 
-    let res = Callout::get_attributes(&mut empty_mdev);
+    let res = callout().get_attributes(&mut empty_mdev);
     let _ = test.assert_result(res, expect, None);
 }
 


### PR DESCRIPTION
I've never been happy with how we handle the `get-attributes` callout action. This series refactors the internals of the callout infrastructure to reduce some duplication and to make it fit better with the other callout actions.

1. First of all, I've refactored the `Callout::callout()` function to make it generic enough (by returning `Output`) so that it can also be used for the `get-attributes` action. This allows us to remove the traversal of callout directories within `Callout::get_attributes()`. 
2. In doing so, I've made it so that if `Callout::script` has already been set (i.e. by a `pre` callout being executed first), `Callout::get_attributes()` will use that script rather than re-iterating the callout script directories to find a script for `get-attributes`. 
3. To actually be able to use the feature mentioned in point 2, we need to change the `func` signature in `Callout::invoke()` to pass a `Callout` object to this callback function. Then we can execute `get_attributes()` from inside of the main operation callback function. This has the additional benefit that the `pre` callout is always issued first before calling `get-attributes`