### PR TITLE
Refactor get attributes extended

### DIFF
--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -108,7 +108,7 @@ impl Callout {
 
     pub fn invoke<F>(&mut self, dev: &mut MDev, action: Action, force: bool, func: F) -> Result<()>
     where
-        F: Fn(&mut MDev) -> Result<()>,
+        F: Fn(&mut Self, &mut MDev) -> Result<()>,
     {
         let res = self
             .callout(dev, Event::Pre, action)
@@ -124,7 +124,7 @@ impl Callout {
                     .ok_or(e)
             })
             .and_then(|_| {
-                let tmp_res = func(dev);
+                let tmp_res = func(self, dev);
                 self.state = match tmp_res {
                     Ok(_) => State::Success,
                     Err(_) => State::Failure,

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,12 +145,14 @@ fn define_command(
         and populate the attrs field correspondingly before the device is defined in the system.
         The device config file will contain the same attributes that were used to start this device。
     */
-    if dev.active {
-        let attrs = callout().get_attributes(&mut dev)?;
-        dev.add_attributes(&attrs)?;
-    }
     callout()
-        .invoke(&mut dev, Action::Define, force, |dev| dev.define())
+        .invoke(&mut dev, Action::Define, force, |c, dev| {
+            if dev.active {
+                let attrs = c.get_attributes(dev)?;
+                dev.add_attributes(&attrs)?;
+            }
+            dev.define()
+        })
         .map(|_| {
             if uuid.is_none() {
                 println!("{}", dev.uuid.hyphenated());
@@ -173,7 +175,9 @@ fn undefine_command(
     }
     for (_, mut children) in devs {
         for child in children.iter_mut() {
-            if let Err(e) = callout().invoke(child, Action::Undefine, force, |dev| dev.undefine()) {
+            if let Err(e) =
+                callout().invoke(child, Action::Undefine, force, |_, dev| dev.undefine())
+            {
                 failed = true;
                 for x in e.chain() {
                     warn!(
@@ -249,7 +253,7 @@ fn modify_command(
         }
     }
 
-    callout().invoke(&mut dev, Action::Modify, force, |dev| dev.write_config())
+    callout().invoke(&mut dev, Action::Modify, force, |_, dev| dev.write_config())
 }
 
 /// convert 'start' command arguments into a MDev struct
@@ -348,7 +352,7 @@ fn start_command(
     let mut dev = start_command_helper(env, uuid, parent, mdev_type, jsonfile)?;
 
     callout()
-        .invoke(&mut dev, Action::Start, force, |dev| dev.start())
+        .invoke(&mut dev, Action::Start, force, |_, dev| dev.start())
         .map(|_| {
             if uuid.is_none() {
                 println!("{}", dev.uuid.hyphenated());
@@ -362,7 +366,7 @@ fn stop_command(env: &dyn Environment, uuid: Uuid, force: bool) -> Result<()> {
     let mut dev = MDev::new(env, uuid);
     dev.load_from_sysfs()?;
 
-    callout().invoke(&mut dev, Action::Stop, force, |dev| dev.stop())
+    callout().invoke(&mut dev, Action::Stop, force, |_, dev| dev.stop())
 }
 
 /// convenience function to lookup a defined device by uuid and parent
@@ -760,7 +764,8 @@ fn start_parent_mdevs_command(env: &dyn Environment, parent: String) -> Result<(
         for child in children {
             if child.autostart {
                 debug!("Autostarting {:?}", child.uuid);
-                if let Err(e) = callout().invoke(child, Action::Start, false, |child| child.start())
+                if let Err(e) =
+                    callout().invoke(child, Action::Start, false, |_, child| child.start())
                 {
                     for x in e.chain() {
                         warn!("{}", x);

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,14 +146,16 @@ fn define_command(
         The device config file will contain the same attributes that were used to start this device。
     */
     if dev.active {
-        let attrs = Callout::get_attributes(&mut dev)?;
+        let attrs = callout().get_attributes(&mut dev)?;
         dev.add_attributes(&attrs)?;
     }
-    Callout::invoke(&mut dev, Action::Define, force, |dev| dev.define()).map(|_| {
-        if uuid.is_none() {
-            println!("{}", dev.uuid.hyphenated());
-        }
-    })
+    callout()
+        .invoke(&mut dev, Action::Define, force, |dev| dev.define())
+        .map(|_| {
+            if uuid.is_none() {
+                println!("{}", dev.uuid.hyphenated());
+            }
+        })
 }
 
 /// Implementation of the `mdevctl undefine` command
@@ -171,7 +173,7 @@ fn undefine_command(
     }
     for (_, mut children) in devs {
         for child in children.iter_mut() {
-            if let Err(e) = Callout::invoke(child, Action::Undefine, force, |dev| dev.undefine()) {
+            if let Err(e) = callout().invoke(child, Action::Undefine, force, |dev| dev.undefine()) {
                 failed = true;
                 for x in e.chain() {
                     warn!(
@@ -247,7 +249,7 @@ fn modify_command(
         }
     }
 
-    Callout::invoke(&mut dev, Action::Modify, force, |dev| dev.write_config())
+    callout().invoke(&mut dev, Action::Modify, force, |dev| dev.write_config())
 }
 
 /// convert 'start' command arguments into a MDev struct
@@ -345,11 +347,13 @@ fn start_command(
 ) -> Result<()> {
     let mut dev = start_command_helper(env, uuid, parent, mdev_type, jsonfile)?;
 
-    Callout::invoke(&mut dev, Action::Start, force, |dev| dev.start()).map(|_| {
-        if uuid.is_none() {
-            println!("{}", dev.uuid.hyphenated());
-        }
-    })
+    callout()
+        .invoke(&mut dev, Action::Start, force, |dev| dev.start())
+        .map(|_| {
+            if uuid.is_none() {
+                println!("{}", dev.uuid.hyphenated());
+            }
+        })
 }
 
 /// Implementation of the `mdevctl stop` command
@@ -358,7 +362,7 @@ fn stop_command(env: &dyn Environment, uuid: Uuid, force: bool) -> Result<()> {
     let mut dev = MDev::new(env, uuid);
     dev.load_from_sysfs()?;
 
-    Callout::invoke(&mut dev, Action::Stop, force, |dev| dev.stop())
+    callout().invoke(&mut dev, Action::Stop, force, |dev| dev.stop())
 }
 
 /// convenience function to lookup a defined device by uuid and parent
@@ -562,7 +566,7 @@ fn list_command_helper(
 
                     // if the device is supported by a callout script that gets attributes, show
                     // those in the output
-                    if let Ok(attrs) = Callout::get_attributes(&mut dev) {
+                    if let Ok(attrs) = callout().get_attributes(&mut dev) {
                         let _ = dev.add_attributes(&attrs);
                     }
 
@@ -756,7 +760,7 @@ fn start_parent_mdevs_command(env: &dyn Environment, parent: String) -> Result<(
         for child in children {
             if child.autostart {
                 debug!("Autostarting {:?}", child.uuid);
-                if let Err(e) = Callout::invoke(child, Action::Start, false, |child| child.start())
+                if let Err(e) = callout().invoke(child, Action::Start, false, |child| child.start())
                 {
                     for x in e.chain() {
                         warn!("{}", x);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1789,13 +1789,13 @@ fn test_invoke_callout<F>(
     empty_mdev.parent = Some(parent.to_string());
 
     let mut callout = callout();
-    let res = callout.invoke(&mut empty_mdev, action, false, |_empty_mdev| Ok(()));
+    let res = callout.invoke(&mut empty_mdev, action, false, |_, _| Ok(()));
     let try_force = res.is_err();
     let _ = test.assert_result(res, expect, Some("non-forced"));
 
     // now force and ensure it succeeds
     if try_force {
-        let res = callout.invoke(&mut empty_mdev, action, true, |_empty_mdev| Ok(()));
+        let res = callout.invoke(&mut empty_mdev, action, true, |_, _| Ok(()));
         let _ = test.assert_result(res, Expect::Pass, Some("forced"));
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1788,13 +1788,14 @@ fn test_invoke_callout<F>(
     empty_mdev.mdev_type = Some(mdev_type.to_string());
     empty_mdev.parent = Some(parent.to_string());
 
-    let res = Callout::invoke(&mut empty_mdev, action, false, |_empty_mdev| Ok(()));
+    let mut callout = callout();
+    let res = callout.invoke(&mut empty_mdev, action, false, |_empty_mdev| Ok(()));
     let try_force = res.is_err();
     let _ = test.assert_result(res, expect, Some("non-forced"));
 
     // now force and ensure it succeeds
     if try_force {
-        let res = Callout::invoke(&mut empty_mdev, action, true, |_empty_mdev| Ok(()));
+        let res = callout.invoke(&mut empty_mdev, action, true, |_empty_mdev| Ok(()));
         let _ = test.assert_result(res, Expect::Pass, Some("forced"));
     }
 }
@@ -1816,7 +1817,7 @@ fn test_get_callout<F>(
     empty_mdev.mdev_type = Some(mdev_type.to_string());
     empty_mdev.parent = Some(parent.to_string());
 
-    let res = Callout::get_attributes(&mut empty_mdev);
+    let res = callout().get_attributes(&mut empty_mdev);
     let _ = test.assert_result(res, expect, None);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1788,14 +1788,14 @@ fn test_invoke_callout<F>(
     empty_mdev.mdev_type = Some(mdev_type.to_string());
     empty_mdev.parent = Some(parent.to_string());
 
-    let mut callout = callout();
-    let res = callout.invoke(&mut empty_mdev, action, false, |_, _| Ok(()));
+    let mut callout = callout(&mut empty_mdev);
+    let res = callout.invoke(action, false, |_| Ok(()));
     let try_force = res.is_err();
     let _ = test.assert_result(res, expect, Some("non-forced"));
 
     // now force and ensure it succeeds
     if try_force {
-        let res = callout.invoke(&mut empty_mdev, action, true, |_, _| Ok(()));
+        let res = callout.invoke(action, true, |_| Ok(()));
         let _ = test.assert_result(res, Expect::Pass, Some("forced"));
     }
 }
@@ -1817,7 +1817,7 @@ fn test_get_callout<F>(
     empty_mdev.mdev_type = Some(mdev_type.to_string());
     empty_mdev.parent = Some(parent.to_string());
 
-    let res = callout().get_attributes(&mut empty_mdev);
+    let res = callout(&mut empty_mdev).get_attributes();
     let _ = test.assert_result(res, expect, None);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1785,7 +1785,10 @@ fn test_invoke_callout<F>(
     setupfn(&test);
 
     let mut empty_mdev = MDev::new(&test, uuid);
-    empty_mdev.mdev_type = Some(mdev_type.to_string());
+    empty_mdev.mdev_type = match mdev_type {
+        "" => None,
+        _ => Some(mdev_type.to_string()),
+    };
     empty_mdev.parent = Some(parent.to_string());
 
     let mut callout = callout(&mut empty_mdev);
@@ -1814,11 +1817,53 @@ fn test_get_callout<F>(
     setupfn(&test);
 
     let mut empty_mdev = MDev::new(&test, uuid);
-    empty_mdev.mdev_type = Some(mdev_type.to_string());
+    empty_mdev.mdev_type = match mdev_type {
+        "" => None,
+        _ => Some(mdev_type.to_string()),
+    };
     empty_mdev.parent = Some(parent.to_string());
 
     let res = callout(&mut empty_mdev).get_attributes();
     let _ = test.assert_result(res, expect, None);
+}
+
+#[test]
+#[should_panic]
+fn test_invoke_callout_panic() {
+    init();
+    const DEFAULT_UUID: &str = "976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9";
+    const DEFAULT_PARENT: &str = "test_parent";
+
+    test_invoke_callout(
+        "test_invoke_callout_create_panic",
+        Expect::Pass,
+        Action::Test,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        "",
+        |test| {
+            test.populate_callout_script("rc0.sh");
+        },
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_get_callout_panic() {
+    init();
+    const DEFAULT_UUID: &str = "976d8cc2-4bfc-43b9-b9f9-f4af2de91ab9";
+    const DEFAULT_PARENT: &str = "test_parent";
+
+    test_get_callout(
+        "test_get_callout_create_panic",
+        Expect::Pass,
+        Uuid::parse_str(DEFAULT_UUID).unwrap(),
+        DEFAULT_PARENT,
+        "",
+        |test| {
+            test.populate_callout_script("rc0.sh");
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
This series ties together the mdev and the callout objects as once the callout object is used for the first time it finds the callout script specifically for the mdev object provided and every other call on the callout object is with that script found first.
By providing the mdev when creating the callout object and removing it as a parameter from the callout functions this relationship is better expressed.