### PR TITLE
cli: adjust help text for modify option addattr

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,7 +137,7 @@ pub enum MdevctlCommands {
             long,
             conflicts_with("delattr"),
             requires("value"),
-            help = "add a new attribute",
+            help = "Add a new attribute",
             value_name = "attr_name"
         )]
         addattr: Option<String>,


### PR DESCRIPTION
Adjust help text for modify option addattr to match the other help texts.