### PR TITLE
tests: use printf over echo

### DIFF
--- a/tests/callouts/bad-json.sh
+++ b/tests/callouts/bad-json.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "not json"
+printf "not json"

--- a/tests/callouts/good-json-null-terminated.sh
+++ b/tests/callouts/good-json-null-terminated.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo -ne "[{\"attribute0\": \"VALUE\"}]\0"
+printf "[{\"attribute0\": \"VALUE\"}]\0"

--- a/tests/callouts/good-json.sh
+++ b/tests/callouts/good-json.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "[{\"attribute0\": \"VALUE\"}]"
+printf "[{\"attribute0\": \"VALUE\"}]"


### PR DESCRIPTION
`echo` + options can run into issues on certain distributions if echo's implementation has been overridden. Though the same case may be present with `printf`, it at least satisfies the Ubuntu-latest CI environment.

Context: the `good-json-null-terminated.sh` file was initially missing its executable privileges, so the GitHub CI gave a false positive. After remedying this, it was apparent that Ubuntu has issues with the `echo -e` flag, though this runs fine on other distros (e.g. fedora). `printf` works for the Ubuntu CI, as well as locally on Fedora.

Fixes 60e377742996 ("trim trailing null from callout script get-attributes output")