### PR TITLE
Callout version live v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 clap = { version = "3.1.18", features = ["derive"]}
 env_logger = "0.8.3"
 log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0", features = ["preserve_order"]}
 uuid = {version = "1.0", features = ["v4"]}
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.8.3"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0", features = ["preserve_order"]}
+serial_test = { version = "1.0.0" }
 uuid = {version = "1.0", features = ["v4"]}
 tempfile = "3"
 

--- a/mdevctl.rst
+++ b/mdevctl.rst
@@ -41,7 +41,8 @@ The following options are understood:
 
 ``-d|--defined``
     List all defined devices, even if not active. Valid for the ``list``
-    command.
+    command. Modify the defined configuration of a device, even if the
+    device is active. Valid for the ``modify`` command.
 
 ``--delattr``
     Delete an attribute entry. Valid for the ``modify`` command.
@@ -57,6 +58,10 @@ The following options are understood:
 ``--jsonfile=FILE``
     Read the configuration for a device from a JSON file *FILE*.
     Valid for the ``define`` and ``start`` commands.
+
+``-l|--live``
+    Modify active device without modifying the defined configuration of
+    the device. Valid for the ``modify`` command.
 
 ``-m|--manual``
     Do not start a device automatically on parent availability. Valid
@@ -111,8 +116,12 @@ The following commands are understood:
     Attributes can be added or deleted. Attributes to be deleted must be
     specified by their index; if an attribute is specified without an
     index, it is appended at the end of the attribute list.
-    Running devices are unaffected by this command; changes in the configuration
-    are applied the next time the device is started.
+    Active devices are unaffected by this command; changes in the configuration
+    are applied the next time the device is started. Depending on installed
+    callout scripts active devices can be modified. With ``-l|--live``
+    modifications can be applied to active devices if a callout scripts supports
+    the event ``live``. The option ``-d|--defined`` also direct the modification
+    to the started device configuration.
 
 ``start`` *DEVICESPEC*
     Start a mediated device. This command can be used to start either a
@@ -352,12 +361,14 @@ file for define, or activating a device for start).
 Essentially, the procedure in mdevctl looks like this:
 
     - command-line parsing & setup
+    - invoke live-command call-out [1]_
     - invoke pre-command call-out
-    - primary command execution [1]_
-    - invoke post-command call-out [1]_
+    - primary command execution [2]_
+    - invoke post-command call-out [2]_
     - invoke notifier
 
-    .. [1] skipped if step 2 fails.
+    .. [1] executed only if live update is requested.
+    .. [2] skipped if step ``invoke pre-command call-out`` fails.
 
 EVENT SCRIPTS
 -------------
@@ -378,7 +389,7 @@ progress, and the mediated device. The parameters are as follows:
 
 ``-e=``\ *event*
     Event type of call-out that is invoked. For call-out scripts, this may be
-    ``pre``, ``post``, or ``get``. For notification scripts, this will
+    ``pre``, ``live``, ``post``, or ``get``. For notification scripts, this will
     always be ``notify``.
 
 ``-a=``\ *action*
@@ -399,8 +410,8 @@ progress, and the mediated device. The parameters are as follows:
 CALL-OUT EVENT SCRIPTS
 ----------------------
 
-A call-out event script is invoked during a ``pre``, ``post``, or ``get``
-event. mdevctl will attempt each script stored in the mdevctl callouts
+A call-out event script is invoked during a ``live``, ``pre``, ``post`` or
+``get`` event. mdevctl will attempt each script stored in the mdevctl callouts
 directory until either a script that satisfies the device type is found or all
 scripts have been attempted. A device script must check the "TYPE" parameter to
 ensure the specified device type is supported, otherwise error code 2 should be
@@ -408,8 +419,25 @@ returned. If no script is found for the specified device type, then mdevctl
 will carry on as normal.
 
 These scripts are stored in */usr/lib/mdevctl/scripts.d/callouts*. The same
-script is invoked for ``pre``, ``post``, and ``get`` call-out events for
-the device type.
+script is invoked for ``live``, ``pre``, ``post``, and ``get`` call-out events
+for the device type.
+
+``Live-Command``
+
+    A live-command call-out event is invoked once before the pre-command call-out
+    event execution. This only occurs if the ``live`` option is specified on the
+    ``modify`` command and the device modified is active.
+    Event type is ``live``. State will always be ``none``.
+
+    If the ``live`` command line option is specified any non-zero return code results in
+    a live modification failure except for all call-outs return with return code 2
+    resulting in a ``live update not supported`` information.
+    The return code is disruptive if also the option ``defined`` is provided and will
+    prevent the update of the defined device configuration.  
+
+    A notification event will follow if the ``live`` command line option is specified.
+
+    This event is only supported for the ``modify`` command.
 
 ``Pre-Command``
 

--- a/mdevctl.rst
+++ b/mdevctl.rst
@@ -468,6 +468,72 @@ the device type.
             }
         ]
 
+``Get-capabilities``
+
+    A get event is invoked on every new mdevctl execution to find a matching script
+    supporting versioning for the device type.
+    Event type is ``get``. Action is ``capabilities``. State is ``none``.
+    Note that, unlike other call-outs events, **get-capabilities provides a
+    versioning JSON on stdin, and a versioning JSON is returned via stdout**.
+    If a script is found the script is used for every event and action for the
+    device type. Should no script be found the none versioning pattern is used.
+
+    If a valid versioning JSON is returned on stdout and the return code is NOT 2
+    the script is a positive match for the provided device type. A script providing
+    versioning is the primary choice for a device type when mdevctl is executing
+    callouts.
+
+    A script is provided on standard in with a versioning JSON describing the mdevctl
+    supported version, actions and events. Example::
+
+        {
+          "provides": {
+            "version": "1.1.0",
+            "actions": [
+              "start",
+              "stop",
+              "define",
+              "undefine",
+              "modify",
+              "attributes",
+              "capabilities"
+            ],
+            "events": [
+              "pre",
+              "post",
+              "notify",
+              "get"
+            ]
+          }
+        }
+
+    A script that wants to support versioning must return a versioning JSON on standard
+    output. The script should list all supported actions in the actions array and all
+    supported events in the events array. It is possible to add additional actions or
+    events in the array but if mdevctl did not have these in the arrays in provides
+    they are ignored. Example::
+
+        {
+          "supports": {
+            "version": "1.1.0",
+            "actions": [
+              "start",
+              "stop",
+              "define",
+              "undefine",
+              "modify",
+              "attributes",
+              "capabilities"
+            ],
+            "events": [
+              "pre",
+              "post",
+              "notify",
+              "get"
+            ]
+          }
+        }
+
 AUTO-START CALL-OUTS
 --------------------
 

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -435,7 +435,6 @@ impl<'a, 'b> Callout<'a, 'b> {
         self.dev.env.find_script(self.dev)
     }
 
-    #[allow(dead_code)]
     pub fn invoke_modify_live(&mut self) -> Result<()> {
         self.script = self.find_callout_script();
         if self.script.is_none() {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -148,6 +148,10 @@ impl<'a, 'b> Callout<'a, 'b> {
                     let mut st = String::from_utf8_lossy(&output.stdout).to_string();
 
                     if st.is_empty() {
+                        debug!(
+                            "Script output for {} is empty",
+                            self.dev.uuid.hyphenated().to_string()
+                        );
                         return Ok(serde_json::Value::Null);
                     }
 
@@ -158,7 +162,11 @@ impl<'a, 'b> Callout<'a, 'b> {
                         );
                         st = "[]".to_string();
                     }
-
+                    debug!(
+                        "Script output for {} is: '{}'",
+                        self.dev.uuid.hyphenated().to_string(),
+                        st
+                    );
                     serde_json::from_str(st.trim_end_matches('\0'))
                         .with_context(|| "Invalid JSON received from callout script")
                 } else {
@@ -168,7 +176,13 @@ impl<'a, 'b> Callout<'a, 'b> {
                     Err(invocation_failure(path, output.status.code()))
                 }
             }
-            None => Ok(serde_json::Value::Null),
+            None => {
+                debug!(
+                    "Script execution for {} returned without error but also without output",
+                    self.dev.uuid.hyphenated().to_string()
+                );
+                Ok(serde_json::Value::Null)
+            }
         }
     }
 

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -259,6 +259,12 @@ impl CalloutScripts {
         }
     }
 
+    // For testing purposes a reset is required
+    #[cfg(test)]
+    pub fn reset(&mut self) {
+        self.callouts.clear();
+    }
+
     fn lockup_callout_script(&self, mdev_type: &str) -> Option<CalloutScript> {
         for cs in self.callouts.iter() {
             if cs.mdev_type.eq_ignore_ascii_case(mdev_type) {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -30,18 +30,10 @@ fn invocation_failure(path: &PathBuf, code: Option<i32>) -> anyhow::Error {
 impl Display for Event {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Event::Pre => {
-                write!(f, "pre")
-            }
-            Event::Post => {
-                write!(f, "post")
-            }
-            Event::Notify => {
-                write!(f, "notify")
-            }
-            Event::Get => {
-                write!(f, "get")
-            }
+            Event::Pre => write!(f, "pre"),
+            Event::Post => write!(f, "post"),
+            Event::Notify => write!(f, "notify"),
+            Event::Get => write!(f, "get"),
         }
     }
 }

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::fmt::{self, Display, Formatter};
 use std::io::Write;
@@ -8,12 +10,16 @@ use std::process::{Command, Output, Stdio};
 
 use crate::mdev::*;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Event {
     Pre,
     Post,
     Notify,
     Get,
+    #[serde(skip_serializing)]
+    #[serde(other)]
+    Unknown, // used for forward compatibility to newer callout scripts
 }
 
 fn invocation_failure(path: &PathBuf, code: Option<i32>) -> anyhow::Error {
@@ -34,12 +40,13 @@ impl Display for Event {
             Event::Post => write!(f, "post"),
             Event::Notify => write!(f, "notify"),
             Event::Get => write!(f, "get"),
+            Event::Unknown => write!(f, "unknown"),
         }
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Action {
     Start,
     Stop,
@@ -47,7 +54,12 @@ pub enum Action {
     Undefine,
     Modify,
     Attributes,
+    Capabilities,
+    #[serde(skip_serializing)]
     Test, // used for tests only
+    #[serde(skip_serializing)]
+    #[serde(other)]
+    Unknown, // used for forward compatibility to newer callout scripts
 }
 
 impl Display for Action {
@@ -59,9 +71,76 @@ impl Display for Action {
             Action::Undefine => write!(f, "undefine"),
             Action::Modify => write!(f, "modify"),
             Action::Attributes => write!(f, "attributes"),
+            Action::Capabilities => write!(f, "capabilities"),
             Action::Test => write!(f, "test"),
+            Action::Unknown => write!(f, "unknown"),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct CalloutVersion {
+    version: Cow<'static, u32>,
+    actions: Cow<'static, [Action]>,
+    events: Cow<'static, [Event]>,
+}
+
+impl CalloutVersion {
+    pub const fn new_const(
+        version: &'static u32,
+        actions: &'static [Action],
+        events: &'static [Event],
+    ) -> Self {
+        Self {
+            version: Cow::Borrowed(version),
+            actions: Cow::Borrowed(actions),
+            events: Cow::Borrowed(events),
+        }
+    }
+
+    pub const V_1: CalloutVersion = CalloutVersion::new_const(
+        &1,
+        &[
+            Action::Start,
+            Action::Stop,
+            Action::Define,
+            Action::Undefine,
+            Action::Modify,
+            Action::Attributes,
+        ],
+        &[Event::Pre, Event::Post, Event::Notify, Event::Get],
+    );
+
+    pub const V_2: CalloutVersion = CalloutVersion::new_const(
+        &2,
+        &[
+            Action::Start,
+            Action::Stop,
+            Action::Define,
+            Action::Undefine,
+            Action::Modify,
+            Action::Attributes,
+            Action::Capabilities,
+        ],
+        &[Event::Pre, Event::Post, Event::Notify, Event::Get],
+    );
+
+    pub fn has_action(&self, action: Action) -> bool {
+        self.actions.contains(&action)
+    }
+
+    pub fn has_event(&self, event: Event) -> bool {
+        self.events.contains(&event)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CalloutExchange {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provides: Option<CalloutVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    supports: Option<CalloutVersion>,
 }
 
 #[derive(Clone, Copy)]
@@ -81,9 +160,217 @@ impl Display for State {
     }
 }
 
+#[derive(Clone)]
+pub struct CalloutScript {
+    path: PathBuf,
+    mdev_type: String,
+    supports: CalloutVersion,
+}
+
+impl std::fmt::Debug for CalloutScript {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("CalloutScript")
+            .field("mdev_type", &self.mdev_type)
+            .field("script", &self.path)
+            .finish()
+    }
+}
+
+impl CalloutScript {
+    fn new(path: PathBuf, mdev_type: String, supports: CalloutVersion) -> CalloutScript {
+        CalloutScript {
+            path,
+            mdev_type,
+            supports,
+        }
+    }
+
+    fn supports_action(&self, action: Action) -> bool {
+        self.supports.has_action(action)
+    }
+
+    fn supports_event(&self, event: Event) -> bool {
+        self.supports.has_event(event)
+    }
+
+    fn supports_event_action(&self, event: Event, action: Action) -> Result<()> {
+        if !self.supports_action(action) {
+            debug!(
+                "Callout script {:?} does not support action '{:?}'",
+                self.path.clone(),
+                action
+            );
+            return Err(anyhow!(
+                "Script {:?} does not support action '{:?}'",
+                self.path.clone(),
+                action
+            ));
+        }
+        if !self.supports_event(event) {
+            debug!(
+                "Callout script {:?} does not support event '{:?}'",
+                self.path.clone(),
+                event
+            );
+            return Err(anyhow!(
+                "Script {:?} does not support event '{:?}'",
+                self.path.clone(),
+                event
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<Path> for CalloutScript {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+pub struct CalloutScripts {
+    callouts: Vec<CalloutScript>,
+}
+
+impl CalloutScripts {
+    pub const fn new() -> Self {
+        CalloutScripts {
+            callouts: Vec::new(),
+        }
+    }
+
+    fn parse_script_output(&self, output: Output) -> Option<CalloutVersion> {
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        match serde_json::from_str::<CalloutExchange>(stdout.trim_end_matches('\0')) {
+            Ok(ce) => match ce.supports {
+                Some(cv) => Some(cv),
+                None => {
+                    debug!(" Callout script does not provide version supported");
+                    None
+                }
+            },
+            Err(e) => {
+                debug!(
+                    " Callout script has no version support (unparsable stdout): {:?}",
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    fn lockup_callout_script(&self, mdev_type: &str) -> Option<CalloutScript> {
+        for cs in self.callouts.iter() {
+            if cs.mdev_type.eq_ignore_ascii_case(mdev_type) {
+                return Some(cs.clone());
+            }
+        }
+        None
+    }
+
+    pub fn find_script(&mut self, dev: &MDev) -> Option<CalloutScript> {
+        // check already found scripts
+        let mut dev = dev.clone();
+        let callout = callout(&mut dev);
+        let mdev_type = callout
+            .dev
+            .mdev_type()
+            .expect("mdev_type is required on device");
+        debug!("Looking up callout script for mdev type '{:?}'", mdev_type);
+        match self.lockup_callout_script(mdev_type) {
+            Some(cs) => {
+                debug!(
+                    "Looked up callout script for mdev type '{:?}': {:?}",
+                    mdev_type, cs.path
+                );
+                return Some(cs);
+            }
+            None => {
+                debug!(
+                    "Lookup failed starting to search for mdev type '{:?}'",
+                    mdev_type
+                );
+            }
+        }
+
+        let ce_ver = CalloutExchange {
+            provides: Some(CalloutVersion::V_2),
+            supports: None,
+        };
+        let json_ce_ver =
+            serde_json::to_string(&ce_ver).expect("CalloutVersion JSON could not be generated");
+
+        for dir in callout.dev.env.callout_dirs() {
+            debug!(
+                "Searching in directory {:?} for mdev type '{:?}'",
+                mdev_type, dir
+            );
+            if !dir.is_dir() {
+                continue;
+            }
+
+            let mut sorted_paths = dir
+                .read_dir()
+                .ok()?
+                .filter_map(|k| k.ok().map(|e| e.path()))
+                .collect::<Vec<_>>();
+            sorted_paths.sort();
+
+            for path in sorted_paths {
+                match callout.invoke_script(
+                    &path,
+                    Event::Get,
+                    Action::Capabilities,
+                    Some(&json_ce_ver),
+                ) {
+                    Ok(output) => {
+                        callout.print_err(&output, &path);
+                        match output.status.code() {
+                            None => {
+                                warn!("callout script {:?} was terminated by a signal", path);
+                                continue;
+                            }
+                            Some(2) => {
+                                // RC 2 == unsupported
+                                debug!(
+                                    "Callout script {:?} does not support mdev type {:?}",
+                                    path, mdev_type
+                                );
+                                continue;
+                            }
+                            _ => {
+                                debug!(
+                                    "Found callout script {:?} supporting mdev type {:?}",
+                                    path, mdev_type
+                                );
+                                match self.parse_script_output(output) {
+                                    Some(cv) => {
+                                        debug!(" Script supports versioning: {:?}", cv);
+                                        let cs = CalloutScript::new(path, mdev_type.clone(), cv);
+                                        self.callouts.push(cs);
+                                        return self.lockup_callout_script(mdev_type);
+                                    }
+                                    None => {
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!("failed to execute callout script {:?}: {:?}", path, e);
+                        continue;
+                    }
+                };
+            }
+        }
+        None
+    }
+}
+
 pub struct Callout<'a, 'b> {
     state: State,
-    script: Option<PathBuf>,
+    script: Option<CalloutScript>,
     pub dev: &'b mut MDev<'a>,
 }
 
@@ -103,10 +390,19 @@ impl<'a, 'b> Callout<'a, 'b> {
         }
     }
 
+    fn find_callout_script(&self) -> Option<CalloutScript> {
+        self.dev.env.find_script(self.dev)
+    }
+
     pub fn invoke<F>(&mut self, action: Action, force: bool, func: F) -> Result<()>
     where
         F: Fn(&mut Self) -> Result<()>,
     {
+        self.script = self.find_callout_script();
+        if self.script.is_none() {
+            debug!("No callout script with version support found");
+        }
+
         let conf = self.dev.to_json(false)?.to_string();
         let res = self
             .callout(Event::Pre, action, Some(&conf))
@@ -141,6 +437,11 @@ impl<'a, 'b> Callout<'a, 'b> {
     }
 
     pub fn get_attributes(&mut self) -> Result<serde_json::Value> {
+        self.script = self.find_callout_script();
+        if self.script.is_none() {
+            debug!("No callout script with version support found");
+        }
+
         match self.callout(Event::Get, Action::Attributes, None)? {
             Some(output) => {
                 if output.status.success() {
@@ -170,7 +471,7 @@ impl<'a, 'b> Callout<'a, 'b> {
                     serde_json::from_str(st.trim_end_matches('\0'))
                         .with_context(|| "Invalid JSON received from callout script")
                 } else {
-                    let path = self.script.as_ref().unwrap();
+                    let path = &self.script.as_ref().unwrap().path;
                     self.print_err(&output, path);
 
                     Err(invocation_failure(path, output.status.code()))
@@ -301,11 +602,18 @@ impl<'a, 'b> Callout<'a, 'b> {
     ) -> Result<Option<Output>> {
         match self.script {
             Some(ref s) => {
+                self.script
+                    .as_ref()
+                    .unwrap()
+                    .supports_event_action(event, action)?;
                 let output = self.invoke_script(s, event, action, stdin)?;
                 self.print_err(&output, s);
                 match output.status.code() {
                     None | Some(0) => Ok(Some(output)),
-                    Some(n) => Err(invocation_failure(self.script.as_ref().unwrap(), Some(n))),
+                    Some(n) => Err(invocation_failure(
+                        &self.script.as_ref().unwrap().path,
+                        Some(n),
+                    )),
                 }
             }
             None => {
@@ -317,7 +625,11 @@ impl<'a, 'b> Callout<'a, 'b> {
                     let r = match self.invoke_first_matching_script(dir, event, action, stdin) {
                         Some((p, o)) => {
                             self.print_err(&o, &p);
-                            self.script = Some(p.clone());
+                            self.script = Some(CalloutScript::new(
+                                p.clone(),
+                                self.dev.mdev_type().unwrap().to_string(),
+                                CalloutVersion::V_1,
+                            ));
                             match o.status.code() {
                                 Some(0) => Ok(Some(o)),
                                 Some(n) => Err(invocation_failure(&p, Some(n))),

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -346,6 +346,18 @@ impl CalloutScripts {
                                 match self.parse_script_output(output) {
                                     Some(cv) => {
                                         debug!(" Script supports versioning: {:?}", cv);
+                                        if cv.has_action(Action::Unknown) {
+                                            warn!(
+                                                "Callout script {:?} provides unknown Action type",
+                                                dir
+                                            );
+                                        }
+                                        if cv.has_event(Event::Unknown) {
+                                            warn!(
+                                                "Callout script {:?} provides unknown Event type",
+                                                dir
+                                            );
+                                        }
                                         let cs = CalloutScript::new(path, mdev_type.clone(), cv);
                                         self.callouts.push(cs);
                                         return self.lockup_callout_script(mdev_type);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,6 +161,15 @@ pub enum MdevctlCommands {
         )]
         manual: bool,
         #[clap(
+            short,
+            long,
+            conflicts_with_all(&["type", "addattr", "delattr", "index", "value", "auto", "manual"]),
+            help = "Modify the running device definition only unless used together with defined option"
+        )]
+        live: bool,
+        #[clap(short, long, help = "Modify the stored device definition")]
+        defined: bool,
+        #[clap(
             long, value_parser,
             conflicts_with_all(&["type", "addattr", "delattr", "index", "value", "auto", "manual"]),
             help = "Specify device details in JSON format"

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,30 @@ fn undefine_command(
     Ok(())
 }
 
+fn dev_from_jsonfile(
+    env: &dyn Environment,
+    uuid: Uuid,
+    parent: Option<String>,
+    jsonfile: Option<PathBuf>,
+) -> Result<Option<MDev>, anyhow::Error> {
+    match jsonfile {
+        Some(jsonfile) => {
+            let _ = std::fs::File::open(&jsonfile)
+                .with_context(|| format!("Unable to read file {:?}", jsonfile));
+            let parent = parent
+                .ok_or_else(|| anyhow!("Parent device required to modify device via json file"))?;
+            let filecontents = fs::read_to_string(&jsonfile)
+                .with_context(|| format!("Unable to read jsonfile {:?}", jsonfile))?;
+            let jsonval = serde_json::from_str(&filecontents)?;
+
+            let mut d = MDev::new(env, uuid);
+            d.load_from_json(parent, &jsonval)?;
+            Ok(Some(d))
+        }
+        _ => Ok(None),
+    }
+}
+
 /// Implementation of the `mdevctl modify` command
 #[allow(clippy::too_many_arguments)]
 fn modify_command(
@@ -213,16 +237,10 @@ fn modify_command(
 ) -> Result<()> {
     let mut dev = get_defined_device(env, uuid, parent.as_ref())?;
 
-    if let Some(jsonfile) = jsonfile {
-        let _ = std::fs::File::open(&jsonfile)
-            .with_context(|| format!("Unable to read file {:?}", jsonfile));
-
-        let mut d = MDev::new(env, uuid);
-        let filecontents = fs::read_to_string(&jsonfile)
-            .with_context(|| format!("Unable to read jsonfile {:?}", jsonfile))?;
-        let jsonval = serde_json::from_str(&filecontents)?;
-        d.load_from_json(dev.parent().unwrap().to_string(), &jsonval)?;
-        dev = d;
+    if jsonfile.is_some() {
+        if let Some(json_dev) = dev_from_jsonfile(env, uuid, parent.clone(), jsonfile)? {
+            dev = json_dev;
+        }
     } else {
         if mdev_type.is_some() {
             dev.mdev_type = mdev_type;

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,76 @@ fn defined_devices<'a>(
     Ok(devices)
 }
 
+/// Get a map of all active devices, optionally filtered by uuid and parent
+fn active_devices<'a>(
+    env: &'a dyn Environment,
+    uuid: Option<&Uuid>,
+    parent: Option<&String>,
+) -> Result<BTreeMap<String, Vec<MDev<'a>>>> {
+    let mut devices: BTreeMap<String, Vec<MDev>> = BTreeMap::new();
+    debug!(
+        "Looking up active mdevs: uuid={:?}, parent={:?}",
+        uuid, parent
+    );
+    if let Ok(dir) = env.mdev_base().read_dir() {
+        for deve in dir {
+            let deve = deve?;
+            let fname = deve.file_name();
+            let basename = fname.to_str().unwrap();
+            debug!("found defined mdev {}", basename);
+            let u = Uuid::parse_str(basename);
+
+            if u.is_err() {
+                warn!("Can't determine uuid for file '{}'", basename);
+                continue;
+            }
+            let u = u.unwrap();
+
+            if uuid.is_some() && uuid != Some(&u) {
+                debug!(
+                    "Ignoring device {} because it doesn't match uuid {}",
+                    u,
+                    uuid.unwrap()
+                );
+                continue;
+            }
+
+            let mut dev = MDev::new(env, u);
+            if dev.load_from_sysfs().is_ok() {
+                if parent.is_some() && (parent != dev.parent.as_ref()) {
+                    debug!(
+                        "Ignoring device {} because it doesn't match parent {}",
+                        dev.uuid,
+                        parent.as_ref().unwrap()
+                    );
+                    continue;
+                }
+
+                let _ = dev.load_definition();
+
+                // don't show attributes from the persistent definition if we're listing
+                // active mdevs. The definition may have changed since the mdev was started
+                dev.attrs.clear();
+
+                // if the device is supported by a callout script that gets attributes, show
+                // those in the output
+                let mut c = callout(&mut dev);
+                if let Ok(attrs) = c.get_attributes() {
+                    let _ = c.dev.add_attributes(&attrs);
+                }
+
+                let devparent = dev.parent()?;
+                if !devices.contains_key(devparent) {
+                    devices.insert(devparent.clone(), Vec::new());
+                };
+
+                devices.get_mut(devparent).unwrap().push(dev);
+            };
+        }
+    }
+    Ok(devices)
+}
+
 /// Implementation of the `mdevctl list` command
 fn list_command(
     env: &dyn Environment,
@@ -521,67 +591,11 @@ fn list_command_helper(
     uuid: Option<Uuid>,
     parent: Option<String>,
 ) -> Result<String> {
-    let mut devices: BTreeMap<String, Vec<MDev>> = BTreeMap::new();
+    let mut devices: BTreeMap<String, Vec<MDev>>;
     if defined {
         devices = defined_devices(env, uuid.as_ref(), parent.as_ref())?;
     } else {
-        debug!("Looking up active mdevs");
-        if let Ok(dir) = env.mdev_base().read_dir() {
-            for dev in dir {
-                let dev = dev?;
-                let fname = dev.file_name();
-                let basename = fname.to_str().unwrap();
-                debug!("found defined mdev {}", basename);
-                let u = Uuid::parse_str(basename);
-
-                if u.is_err() {
-                    warn!("Can't determine uuid for file '{}'", basename);
-                    continue;
-                }
-                let u = u.unwrap();
-
-                if uuid.is_some() && uuid != Some(u) {
-                    debug!(
-                        "Ignoring device {} because it doesn't match uuid {}",
-                        u,
-                        uuid.unwrap()
-                    );
-                    continue;
-                }
-
-                let mut dev = MDev::new(env, u);
-                if dev.load_from_sysfs().is_ok() {
-                    if parent.is_some() && (parent != dev.parent) {
-                        debug!(
-                            "Ignoring device {} because it doesn't match parent {}",
-                            dev.uuid,
-                            parent.as_ref().unwrap()
-                        );
-                        continue;
-                    }
-
-                    let _ = dev.load_definition();
-
-                    // don't show attributes from the persistent definition if we're listing
-                    // active mdevs. The definition may have changed since the mdev was started
-                    dev.attrs.clear();
-
-                    // if the device is supported by a callout script that gets attributes, show
-                    // those in the output
-                    let mut c = callout(&mut dev);
-                    if let Ok(attrs) = c.get_attributes() {
-                        let _ = c.dev.add_attributes(&attrs);
-                    }
-
-                    let devparent = dev.parent()?;
-                    if !devices.contains_key(devparent) {
-                        devices.insert(devparent.clone(), Vec::new());
-                    };
-
-                    devices.get_mut(devparent).unwrap().push(dev);
-                };
-            }
-        }
+        devices = active_devices(env, uuid.as_ref(), parent.as_ref())?;
     }
 
     // ensure that devices are sorted in a stable order

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use log::info;
 use nix::sys::wait::waitpid;
 use nix::unistd::{fork, ForkResult};
+use serial_test::serial;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
@@ -376,6 +377,7 @@ fn test_define_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_define() {
     init();
 
@@ -634,6 +636,7 @@ fn test_modify_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_modify() {
     init();
 
@@ -944,6 +947,7 @@ fn test_undefine_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_undefine() {
     init();
 
@@ -1096,6 +1100,7 @@ fn test_start_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_start() {
     init();
 
@@ -1401,6 +1406,7 @@ where
 }
 
 #[test]
+#[serial]
 fn test_stop() {
     init();
 
@@ -1426,6 +1432,7 @@ fn test_stop() {
 }
 
 #[test]
+#[serial]
 fn test_invalid_files() {
     init();
 
@@ -1473,6 +1480,7 @@ fn test_list_helper<F>(
 }
 
 #[test]
+#[serial]
 fn test_list() {
     init();
 
@@ -1714,6 +1722,7 @@ fn test_types_helper(
 }
 
 #[test]
+#[serial]
 fn test_types() {
     init();
 
@@ -1835,6 +1844,7 @@ fn test_get_callout<F>(
 }
 
 #[test]
+#[serial]
 #[should_panic]
 fn test_invoke_callout_panic() {
     init();
@@ -1855,6 +1865,7 @@ fn test_invoke_callout_panic() {
 }
 
 #[test]
+#[serial]
 #[should_panic]
 fn test_get_callout_panic() {
     init();
@@ -1874,6 +1885,7 @@ fn test_get_callout_panic() {
 }
 
 #[test]
+#[serial]
 fn test_callouts() {
     init();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,6 +31,10 @@ enum Expect<'a> {
 
 static CALLOUT_SCRIPTS: Mutex<CalloutScripts> = Mutex::new(CalloutScripts::new());
 
+fn reset_callout_scripts() {
+    return CALLOUT_SCRIPTS.lock().unwrap().reset();
+}
+
 #[derive(Debug)]
 struct TestEnvironment {
     datapath: PathBuf,
@@ -71,6 +75,7 @@ impl TestEnvironment {
             fs::create_dir_all(&dir)
                 .expect(format!("Unable to create notification_dir '{:?}'", &dir).as_str());
         }
+        reset_callout_scripts();
         info!("---- Running test '{}/{}' ----", testname, testcase);
         test
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -684,6 +684,8 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
+        false,
+        false,
         jsonfile,
         force,
     );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -580,6 +580,67 @@ fn test_define() {
             test.populate_callout_script("rc1.sh");
         },
     );
+
+    // test define with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    test_define_command_callout(
+        "define-with-version-callout-all-pass",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-all-fail",
+        Expect::Fail(None),
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_modify_helper<F>(
@@ -924,6 +985,108 @@ fn test_modify() {
             test.populate_callout_script("rc1.sh");
         },
     );
+
+    // test modify with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_undefine_helper<F>(
@@ -1039,6 +1202,68 @@ fn test_undefine() {
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
             test.populate_callout_script("rc1.sh");
+        },
+    );
+
+    // test define with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_undefine_helper(
+        "undefine-single-with-version-callout-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "undefine-single-with-version-callout-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
         },
     );
 }
@@ -1391,6 +1616,78 @@ fn test_start() {
     // TODO: test attributes -- difficult because executing the 'start' command by writing to
     // the 'create' file in sysfs does not automatically create the device file structure in
     // the temporary test environment, so writing the sysfs attribute files fails.
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_start_command_callout(
+        "start-single-with-version-callout-pass",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-single-with-version-callout-fail",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_stop_helper<F>(testname: &str, expect: Expect, uuid: &str, force: bool, setupfn: F)
@@ -1434,6 +1731,52 @@ fn test_stop() {
         t.populate_active_device(UUID, PARENT, MDEV_TYPE);
         t.populate_callout_script("rc1.sh")
     });
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_stop_helper(
+        "stop-single-callout-with-version-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callout-with-version-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("ver-rc1.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callouts-mix-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callouts-mix-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning
+        },
+    );
 }
 
 #[test]
@@ -2119,6 +2462,191 @@ fn test_callouts() {
         DEFAULT_TYPE,
         |test| {
             test.populate_callout_script("good-json-null-terminated.sh");
+        },
+    );
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    const UUID_VER_RC1: &str = "11111111-1111-0000-0000-111111111111";
+    const UUID_VER_RC2: &str = "11111111-1111-0000-0000-222222222222";
+    const UUID_VER_BAD_JSON: &str = "11111111-1111-0000-0000-aaaaaaaaaaaa";
+    const UUID_VER_ACTION_DUMMY: &str = "11111111-1111-0000-0000-bbbbbbbbbbbb";
+    const UUID_VER_EVENT_DUMMY: &str = "11111111-1111-0000-0000-cccccccccccc";
+    const UUID_VER_MODIFY_MISSING: &str = "11111111-1111-0000-0000-dddddddddddd";
+    const UUID_VER_PROVIDES: &str = "11111111-1111-0000-0000-eeeeeeeeeeee";
+    const UUID_VER_INVALID_JSON: &str = "11111111-1111-0000-0000-ffffffffffff";
+
+    test_invoke_callout(
+        "test_callout_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_mix_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_mix_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_get_callout(
+        "test_callout_with_version_good_json",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_get_callout(
+        "test_callout_with_version_bad_json",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0-get-attr-bad-json.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_get_capabilities_rc1_run_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_RC1).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_get_capabilities_rc2_run_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_RC2).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_get_capabilities_bad_run_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_BAD_JSON).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_unknown_action_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_ACTION_DUMMY).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_unknown_event_with_verion_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_EVENT_DUMMY).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_missing_modify_run_start_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_MODIFY_MISSING).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_missing_modify_run_modify_fail",
+        Expect::Fail(None),
+        Action::Modify,
+        Uuid::parse_str(UUID_VER_MODIFY_MISSING).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_json_provides_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_PROVIDES).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_json_invalid_with_version_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_INVALID_JSON).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
         },
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -655,6 +655,8 @@ fn test_modify_helper<F>(
     value: Option<String>,
     auto: bool,
     manual: bool,
+    live: bool,
+    defined: bool,
     jsonfile: Option<PathBuf>,
     force: bool,
     setupfn: F,
@@ -684,8 +686,8 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
-        false,
-        false,
+        live,
+        defined,
         jsonfile,
         force,
     );
@@ -701,6 +703,81 @@ fn test_modify_helper<F>(
     assert!(def.is_defined());
     let filecontents = fs::read_to_string(&path).unwrap();
     test.compare_to_file(&format!("{}.expected", testname), &filecontents);
+}
+
+fn test_modify_defined_active_helper<F>(
+    testname: &str,
+    expect: Expect,
+    uuid: &str,
+    parent: Option<String>,
+    mdev_type: Option<String>,
+    addattr: Option<String>,
+    delattr: bool,
+    index: Option<u32>,
+    value: Option<String>,
+    auto: bool,
+    manual: bool,
+    live: bool,
+    defined: bool,
+    jsonfile: Option<PathBuf>,
+    force: bool,
+    setupfn: F,
+) where
+    F: Fn(&TestEnvironment),
+{
+    use crate::modify_command;
+    let test = TestEnvironment::new("modify", testname);
+
+    // load the jsonfile from the test path.
+    let jsonfile = match jsonfile {
+        Some(f) => Some(test.datapath.join(f)),
+        None => None,
+    };
+
+    setupfn(&test);
+
+    let uuid = Uuid::parse_str(uuid).unwrap();
+    let result = modify_command(
+        &test,
+        uuid,
+        parent.clone(),
+        mdev_type,
+        addattr,
+        delattr,
+        index,
+        value,
+        auto,
+        manual,
+        live,
+        defined,
+        jsonfile,
+        force,
+    );
+    if test
+        .assert_result(result, expect, Some("modify command"))
+        .is_err()
+    {
+        return;
+    }
+
+    let def_active = crate::get_active_device(&test, uuid, parent.as_ref())
+        .expect("Couldn't find defined device");
+    assert!(def_active.active);
+    let def_json = serde_json::to_string_pretty(
+        &def_active
+            .to_json(false)
+            .expect("Couldn't get json from active device"),
+    )
+    .expect("Couldn't get json from active device");
+    test.compare_to_file(&format!("{}.active.expected", testname), &def_json);
+
+    let def = crate::get_defined_device(&test, uuid, parent.as_ref())
+        .expect("Couldn't find defined device");
+    let path = def.persist_path().unwrap();
+    assert!(path.exists());
+    assert!(def.is_defined());
+    let filecontents = fs::read_to_string(&path).unwrap();
+    test.compare_to_file(&format!("{}.defined.expected", testname), &filecontents);
 }
 
 #[test]
@@ -722,6 +799,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         None,
         false,
         |_| {},
@@ -737,6 +816,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         false,
@@ -756,6 +837,8 @@ fn test_modify() {
         None,
         false,
         true,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -772,6 +855,8 @@ fn test_modify() {
         true,
         Some(2),
         None,
+        false,
+        false,
         false,
         false,
         None,
@@ -792,6 +877,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -808,6 +895,8 @@ fn test_modify() {
         false,
         Some(3),
         Some("added-attr-value".to_string()),
+        false,
+        false,
         false,
         false,
         None,
@@ -828,6 +917,8 @@ fn test_modify() {
         Some("added-attr-value".to_string()),
         false,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -844,6 +935,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         None,
@@ -864,6 +957,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -882,6 +977,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         false,
@@ -902,6 +999,8 @@ fn test_modify() {
         None,
         true,
         true,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -919,6 +1018,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         Some(PathBuf::from("modified.json")),
@@ -940,6 +1041,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -960,6 +1063,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -979,6 +1084,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         true,
@@ -1003,6 +1110,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1022,6 +1131,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1039,6 +1150,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         Some(PathBuf::from("modified.json")),
@@ -1061,6 +1174,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1081,12 +1196,200 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
             test.populate_defined_device(UUID_VER, PARENT, "defined.json");
             test.populate_callout_script("rc0.sh"); // no versioning
             test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_NO_LIVE: &str = "11111111-1111-0000-0000-000000000000";
+    const UUID_LIVE: &str = "11111111-1111-1111-0000-000000000000";
+
+    test_modify_helper(
+        "live-event-supported",
+        Expect::Pass,
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-event-unsupported-by-callout",
+        Expect::Fail(None),
+        UUID_NO_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_NO_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_NO_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-unsupported-script-without-version-support",
+        Expect::Fail(Some(
+            format!("'jsonfile' option must be used with 'live' option").as_str(),
+        )),
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_active_device(UUID, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-supported-but-fails",
+        Expect::Fail(None),
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc1.sh");
+        },
+    );
+    test_modify_helper(
+        "live-fail-without-jsonfile",
+        Expect::Fail(Some(
+            format!("'jsonfile' option must be used with 'live' option").as_str(),
+        )),
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+
+    test_modify_defined_active_helper(
+        "live-defined-supported",
+        Expect::Pass,
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        true,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
+        },
+    );
+    test_modify_defined_active_helper(
+        "live-defined-live-event-unsupported",
+        Expect::Fail(None),
+        UUID_NO_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        true,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_NO_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_NO_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
+        },
+    );
+    test_modify_defined_active_helper(
+        "defined-only",
+        Expect::Pass,
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        Some("added-attr".to_string()),
+        false,
+        None,
+        Some("added-attr-value".to_string()),
+        false,
+        false,
+        false,
+        true,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_active_device(UUID, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
         },
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use tempfile::Builder;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -27,6 +28,8 @@ enum Expect<'a> {
     Fail(Option<&'a str>),
 }
 
+static CALLOUT_SCRIPTS: Mutex<CalloutScripts> = Mutex::new(CalloutScripts::new());
+
 #[derive(Debug)]
 struct TestEnvironment {
     datapath: PathBuf,
@@ -38,6 +41,10 @@ struct TestEnvironment {
 impl Environment for TestEnvironment {
     fn root(&self) -> &Path {
         self.scratch.path()
+    }
+
+    fn find_script(&self, dev: &MDev) -> Option<CalloutScript> {
+        return CALLOUT_SCRIPTS.lock().unwrap().find_script(dev);
     }
 }
 

--- a/tests/callouts/live-rc0.sh
+++ b/tests/callouts/live-rc0.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 3 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":3,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            *)
+                exit 0
+            ;;
+        esac
+    ;;
+    live)
+        exit 0
+    ;;
+    *)
+        exit 0
+    ;;
+esac

--- a/tests/callouts/live-rc1.sh
+++ b/tests/callouts/live-rc1.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 3 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":3,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            *)
+                exit 0
+            ;;
+        esac
+    ;;
+    live)
+        exit 1
+    ;;
+    *)
+        exit 0
+    ;;
+esac

--- a/tests/callouts/modify-active.sh
+++ b/tests/callouts/modify-active.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+tempfile="tmp_modify-live.json"
+
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 3 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":3,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    pre)
+        case "$action" in
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version "$uuid"
+            ;;
+            attributes)
+                if [ -f "$tempfile" ]; then
+                    cat "$tempfile"
+                    rm "$tempfile"
+                else
+                        echo "[]"
+                fi
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    post)
+        case "$action" in
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    live)
+        case "$action" in
+            modify)
+                echo "$json" | grep -oP '"attrs":+\K(\[.*\])' > "$tempfile"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/params.sh
+++ b/tests/callouts/params.sh
@@ -15,7 +15,7 @@ shift 2
 uuid=$1
 shift 2
 parent=$1
-json=$(</dev/stdin)
+json=$(cat)
 
 test_params() {
     test_parent=$1

--- a/tests/callouts/rc0.sh
+++ b/tests/callouts/rc0.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-json=$(</dev/stdin)
+json=$(cat)
 exit 0

--- a/tests/callouts/rc1.sh
+++ b/tests/callouts/rc1.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-json=$(</dev/stdin)
+json=$(cat)
 exit 1

--- a/tests/callouts/rc2.sh
+++ b/tests/callouts/rc2.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-json=$(</dev/stdin)
+json=$(cat)
 exit 2

--- a/tests/callouts/template.sh
+++ b/tests/callouts/template.sh
@@ -15,6 +15,6 @@ shift 2
 uuid=$1
 shift 2
 parent=$1
-json=$(</dev/stdin)
+json=$(cat)
 
 # do stuff here

--- a/tests/callouts/type-a.sh
+++ b/tests/callouts/type-a.sh
@@ -15,7 +15,7 @@ shift 2
 uuid=$1
 shift 2
 parent=$1
-json=$(</dev/stdin)
+json=$(cat)
 
 if [ "$type" = "type_a" ]; then
 	exit 0

--- a/tests/callouts/type-b.sh
+++ b/tests/callouts/type-b.sh
@@ -15,7 +15,7 @@ shift 2
 uuid=$1
 shift 2
 parent=$1
-json=$(</dev/stdin)
+json=$(cat)
 
 if [ "$type" = "type_b" ]; then
 	exit 0

--- a/tests/callouts/type-c.sh
+++ b/tests/callouts/type-c.sh
@@ -15,7 +15,7 @@ shift 2
 uuid=$1
 shift 2
 parent=$1
-json=$(</dev/stdin)
+json=$(cat)
 
 if [ "$type" = "type_c" ]; then
 	exit 1 # this test expects to fail

--- a/tests/callouts/ver-rc0-get-attr-bad-json.sh
+++ b/tests/callouts/ver-rc0-get-attr-bad-json.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-222222222222)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":\111111,"
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "not json"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/ver-rc0.sh
+++ b/tests/callouts/ver-rc0.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-222222222222)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":111111,"
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "[{\"attribute0\": \"VALUE\"}]"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    pre)
+        case "$action" in
+            define)
+                exit 0
+            ;;
+            undefine)
+                exit 0
+            ;;
+            start)
+                exit 0
+            ;;
+            stop)
+                exit 0
+            ;;
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    post)
+        case "$action" in
+            define)
+                exit 0
+            ;;
+            undefine)
+                exit 0
+            ;;
+            start)
+                exit 0
+            ;;
+            stop)
+                exit 0
+            ;;
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/ver-rc1.sh
+++ b/tests/callouts/ver-rc1.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":111111,"
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "[{\"attribute0\": \"VALUE\"}]"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/modify/defined-only.active.expected
+++ b/tests/modify/defined-only.active.expected
@@ -1,0 +1,5 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": []
+}

--- a/tests/modify/defined-only.defined.expected
+++ b/tests/modify/defined-only.defined.expected
@@ -1,0 +1,27 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    },
+    {
+      "added-attr": "added-attr-value"
+    }
+  ]
+}

--- a/tests/modify/live-defined-supported.active.expected
+++ b/tests/modify/live-defined-supported.active.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/live-defined-supported.defined.expected
+++ b/tests/modify/live-defined-supported.defined.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/live-event-supported.expected
+++ b/tests/modify/live-event-supported.expected
@@ -1,0 +1,24 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-all-pass.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-all-pass.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass2.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass2.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}


### PR DESCRIPTION
The first three patches are kind of generic and resulting from working on this series.
The next five patches add callout version support and the last six patches add live modify support exploiting the callout version support.

In v3 I tried to address most comments made on v2.
As I already mentioned I only partially succeeded to include the formally global singleton into Environment. Feedback for improving this is very welcome.

I also noticed an improvement can be implemented by storing the failure state when find_script does not find a matching script. This can get relevant when list is called on many mdev instances with an mdev type that does not resolve in a match. I will add this performance improvement later.