### PR TITLE
mdevctl.spec.in: Add systemd as build requirement

### DIFF
--- a/mdevctl.spec.in
+++ b/mdevctl.spec.in
@@ -35,7 +35,7 @@ BuildRequires:  rust-packaging
 %if 0%{?rhel}
 BuildRequires: rust-toolset
 %endif
-BuildRequires: python3-docutils
+BuildRequires: systemd python3-docutils
 
 %global _description %{expand:
 %{summary}.}


### PR DESCRIPTION
Add systemd as build requirement as otherwise _udevrulesdir is not set correctly and the build fails with
File must begin with "/": %{_udevrulesdir}