### PR TITLE
main: assemble active devices without overwriting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -560,11 +560,12 @@ fn list_command_helper(
                         continue;
                     }
 
-                    let _ = dev.load_definition();
-
-                    // don't show attributes from the persistent definition if we're listing
-                    // active mdevs. The definition may have changed since the mdev was started
-                    dev.attrs.clear();
+                    // retrieve autostart from persisted mdev if possible
+                    let mut per_dev = MDev::new(env, u);
+                    per_dev.parent = dev.parent.clone();
+                    if per_dev.load_definition().is_ok() {
+                        dev.autostart = per_dev.autostart;
+                    }
 
                     // if the device is supported by a callout script that gets attributes, show
                     // those in the output


### PR DESCRIPTION
Active devices are created from loading the sysfs information. Autostart is the only attribute that must be retrieved from the persisted configuration if it exists. Instead of loading the persisted configuration into the retrieved active mdev data which overwrite valid active mdev settings be more surgical and use a new mdev for loading the configuration and the only copy the autostart attribute to the active mdev.