### PR TITLE
Cargo.toml: move tempfile to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ env_logger = "0.9.0"
 log = "0.4"
 serde_json = {version = "1.0", features = ["preserve_order"]}
 uuid = {version = "1.0", features = ["v4"]}
-tempfile = "3"
 
 [build-dependencies]
 clap = { version = "4.0", features = ["derive"]}
@@ -28,3 +27,4 @@ uuid = "1.0"
 [dev-dependencies]
 nix = "0.26"
 libc = "0.2"
+tempfile = "3"


### PR DESCRIPTION
This is only used as a test dependency. There is no need to pull this in for package builds. Moreover, it should not be listed as a dependency.