### PR TITLE
Callout version live v6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 clap = { version = "4.0", features = ["derive", "wrap_help"] }
 env_logger = "0.9.0"
 log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = {version = "1.0", features = ["preserve_order"]}
 uuid = {version = "1.0", features = ["v4"]}
 

--- a/mdevctl.rst
+++ b/mdevctl.rst
@@ -41,7 +41,8 @@ The following options are understood:
 
 ``-d|--defined``
     List all defined devices, even if not active. Valid for the ``list``
-    command.
+    command. Modify the defined configuration of a device, even if the
+    device is active. Valid for the ``modify`` command.
 
 ``--delattr``
     Delete an attribute entry. Valid for the ``modify`` command.
@@ -57,6 +58,10 @@ The following options are understood:
 ``--jsonfile=FILE``
     Read the configuration for a device from a JSON file *FILE*.
     Valid for the ``define`` and ``start`` commands.
+
+``-l|--live``
+    Modify active device without modifying the defined configuration of
+    the device. Valid for the ``modify`` command.
 
 ``-m|--manual``
     Do not start a device automatically on parent availability. Valid
@@ -111,8 +116,12 @@ The following commands are understood:
     Attributes can be added or deleted. Attributes to be deleted must be
     specified by their index; if an attribute is specified without an
     index, it is appended at the end of the attribute list.
-    Running devices are unaffected by this command; changes in the configuration
-    are applied the next time the device is started.
+    Active devices are unaffected by this command; changes in the configuration
+    are applied the next time the device is started. Depending on installed
+    callout scripts active devices can be modified. With ``-l|--live``
+    modifications can be applied to active devices if a callout scripts supports
+    the event ``live``. The option ``-d|--defined`` also direct the modification
+    to the started device configuration.
 
 ``start`` *DEVICESPEC*
     Start a mediated device. This command can be used to start either a
@@ -352,12 +361,14 @@ file for define, or activating a device for start).
 Essentially, the procedure in mdevctl looks like this:
 
     - command-line parsing & setup
+    - invoke live-command call-out [1]_
     - invoke pre-command call-out
-    - primary command execution [1]_
-    - invoke post-command call-out [1]_
+    - primary command execution [2]_
+    - invoke post-command call-out [2]_
     - invoke notifier
 
-    .. [1] skipped if step 2 fails.
+    .. [1] executed only if live update is requested.
+    .. [2] skipped if step ``invoke pre-command call-out`` fails.
 
 EVENT SCRIPTS
 -------------
@@ -378,7 +389,7 @@ progress, and the mediated device. The parameters are as follows:
 
 ``-e=``\ *event*
     Event type of call-out that is invoked. For call-out scripts, this may be
-    ``pre``, ``post``, or ``get``. For notification scripts, this will
+    ``pre``, ``live``, ``post``, or ``get``. For notification scripts, this will
     always be ``notify``.
 
 ``-a=``\ *action*
@@ -399,8 +410,8 @@ progress, and the mediated device. The parameters are as follows:
 CALL-OUT EVENT SCRIPTS
 ----------------------
 
-A call-out event script is invoked during a ``pre``, ``post``, or ``get``
-event. mdevctl will attempt each script stored in the mdevctl callouts
+A call-out event script is invoked during a ``live``, ``pre``, ``post`` or
+``get`` event. mdevctl will attempt each script stored in the mdevctl callouts
 directory until either a script that satisfies the device type is found or all
 scripts have been attempted. A device script must check the "TYPE" parameter to
 ensure the specified device type is supported, otherwise error code 2 should be
@@ -408,8 +419,25 @@ returned. If no script is found for the specified device type, then mdevctl
 will carry on as normal.
 
 These scripts are stored in */usr/lib/mdevctl/scripts.d/callouts*. The same
-script is invoked for ``pre``, ``post``, and ``get`` call-out events for
-the device type.
+script is invoked for ``live``, ``pre``, ``post``, and ``get`` call-out events
+for the device type.
+
+``Live-Command``
+
+    A live-command call-out event is invoked once before the pre-command call-out
+    event execution. This only occurs if the ``live`` option is specified on the
+    ``modify`` command and the device modified is active.
+    Event type is ``live``. State will always be ``none``.
+
+    If the ``live`` command line option is specified any non-zero return code results in
+    a live modification failure except for all call-outs return with return code 2
+    resulting in a ``live update not supported`` information.
+    The return code is disruptive if also the option ``defined`` is provided and will
+    prevent the update of the defined device configuration.  
+
+    A notification event will follow if the ``live`` command line option is specified.
+
+    This event is only supported for the ``modify`` command.
 
 ``Pre-Command``
 

--- a/mdevctl.rst
+++ b/mdevctl.rst
@@ -468,6 +468,80 @@ the device type.
             }
         ]
 
+``Get-capabilities``
+
+    A get event is invoked on every new mdevctl execution to find a matching script
+    supporting versioning for the device type.
+    Event type is ``get``. Action is ``capabilities``. State is ``none``.
+    Note that, unlike other call-outs events, **get-capabilities provides a
+    versioning JSON on stdin, and expects a versioning JSON is returned via
+    stdout**.
+    The provided JSON on stdin explains in ``provides`` which ``actions`` and
+    ``events`` mdevctl supports. The information is offered to the script to
+    derive its supported ``actions`` and ``events`` from but it there is no
+    obligation for scripts to follow this pattern.
+    A valid versioning JSON response provides in ``supports`` the supported
+    actions in ``actions`` and the supported events in ``events``.
+
+    If a valid versioning JSON is returned on stdout by the script and the
+    return code is NOT 2 the script is considered a positive match for the
+    provided device type. A script providing versioning is the primary choice
+    for a device type when mdevctl is executing callouts or in other words if
+    a script which supports versioning is found the script is used for every
+    event and action for the device type. Should no versioning supporting
+    script be found the none versioning search pattern is used.
+
+    A script is provided on standard in with a versioning JSON describing the mdevctl
+    supported version, actions and events. Example::
+
+        {
+          "provides": {
+            "version": 1,
+            "actions": [
+              "start",
+              "stop",
+              "define",
+              "undefine",
+              "modify",
+              "attributes",
+              "capabilities"
+            ],
+            "events": [
+              "pre",
+              "post",
+              "notify",
+              "get"
+            ]
+          }
+        }
+
+    A script that wants to support versioning must return a versioning JSON on standard
+    output. The script should list all supported actions in the actions array and all
+    supported events in the events array. It is possible to add additional actions or
+    events in the array but if mdevctl did not have these in the arrays in provides
+    they are ignored. Example::
+
+        {
+          "supports": {
+            "version": 1,
+            "actions": [
+              "start",
+              "stop",
+              "define",
+              "undefine",
+              "modify",
+              "attributes",
+              "capabilities"
+            ],
+            "events": [
+              "pre",
+              "post",
+              "notify",
+              "get"
+            ]
+          }
+        }
+
 AUTO-START CALL-OUTS
 --------------------
 

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -78,7 +78,7 @@ impl Display for Action {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub struct CalloutVersion {
     version: Cow<'static, u32>,
@@ -98,6 +98,8 @@ impl CalloutVersion {
             events: Cow::Borrowed(events),
         }
     }
+
+    pub const NOT_FOUND: CalloutVersion = CalloutVersion::new_const(&0, &[], &[]);
 
     pub const V_1: CalloutVersion = CalloutVersion::new_const(
         &1,
@@ -278,10 +280,16 @@ impl CalloutScriptCache {
         match self.lookup_callout_script(&parent, &mdev_type) {
             Some(cs) => {
                 debug!(
-                    "Looked up callout script for mdev type '{:?}' and parent {:?}: {:?}",
-                    mdev_type, parent, cs.path
+                    "Callout script lookup for mdev type '{:?}' and parent {:?} successful",
+                    mdev_type, parent
                 );
-                return Some(cs);
+                if cs.supports == CalloutVersion::NOT_FOUND && cs.path.as_os_str().is_empty() {
+                    debug!("Callout script search returned empty before: no script with versioning available");
+                    return None;
+                } else {
+                    debug!("Callout script looked up: {:?}", cs.path);
+                    return Some(cs);
+                }
             }
             None => {
                 debug!(
@@ -308,7 +316,16 @@ impl CalloutScriptCache {
                     self.callouts.push(callout.script.clone().unwrap());
                     callout.script
                 }
-                None => None,
+                None => {
+                    // When lookup and search turned out empty create a did-not-find entry.
+                    self.callouts.push(CalloutScriptInfo::new(
+                        PathBuf::new(),
+                        parent,
+                        mdev_type,
+                        CalloutVersion::NOT_FOUND,
+                    ));
+                    None
+                }
             },
             Err(_) => None,
         }

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -434,7 +434,6 @@ impl<'a, 'b> Callout<'a, 'b> {
         self.dev.env.find_script(self.dev)
     }
 
-    #[allow(dead_code)]
     pub fn invoke_modify_live(&mut self) -> Result<()> {
         self.script = self.find_callout_script();
         if self.script.is_none() {

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -15,6 +15,7 @@ use crate::mdev::*;
 pub enum Event {
     Pre,
     Post,
+    Live,
     Notify,
     Get,
     #[serde(skip_serializing)]
@@ -38,6 +39,7 @@ impl Display for Event {
         match self {
             Event::Pre => write!(f, "pre"),
             Event::Post => write!(f, "post"),
+            Event::Live => write!(f, "live"),
             Event::Notify => write!(f, "notify"),
             Event::Get => write!(f, "get"),
             Event::Unknown => write!(f, "unknown"),
@@ -114,6 +116,7 @@ impl CalloutVersion {
         &[Event::Pre, Event::Post, Event::Notify, Event::Get],
     );
 
+    #[allow(dead_code)]
     pub const V_2: CalloutVersion = CalloutVersion::new_const(
         &2,
         &[
@@ -125,7 +128,13 @@ impl CalloutVersion {
             Action::Attributes,
             Action::Capabilities,
         ],
-        &[Event::Pre, Event::Post, Event::Notify, Event::Get],
+        &[
+            Event::Pre,
+            Event::Post,
+            Event::Notify,
+            Event::Get,
+            Event::Live,
+        ],
     );
 
     pub fn has_action(&self, action: Action) -> bool {
@@ -423,6 +432,50 @@ impl<'a, 'b> Callout<'a, 'b> {
 
     fn find_callout_script(&self) -> Option<CalloutScriptInfo> {
         self.dev.env.find_script(self.dev)
+    }
+
+    #[allow(dead_code)]
+    pub fn invoke_modify_live(&mut self) -> Result<()> {
+        self.script = self.find_callout_script();
+        if self.script.is_none() {
+            // live is only supported when script with versioning exists
+            debug!("No callout script with version support found that supports live modify");
+            return Err(anyhow!(
+                "No callout script with version support found that supports live modify"
+            ));
+        }
+
+        let mut res = Ok(());
+        let mut existing = MDev::new(self.dev.env, self.dev.uuid);
+        if existing.load_from_sysfs().is_ok() && existing.active {
+            if existing.parent != self.dev.parent {
+                debug!("Device exists under different parent - cannot run live update");
+                res = Err(anyhow!(
+                    "Device exists under different parent - cannot run live update"
+                ));
+            } else if existing.mdev_type != self.dev.mdev_type {
+                debug!("Device exists with different type - cannot run live update");
+                res = Err(anyhow!(
+                    "Device exists with different type - cannot run live update"
+                ));
+            } else {
+                self.script
+                    .clone()
+                    .unwrap()
+                    .supports_event_action(Event::Live, Action::Modify)?;
+                let conf = self.dev.to_json(false)?.to_string();
+                res = self
+                    .callout(
+                        Event::Live,
+                        Action::Modify,
+                        Some(&conf),
+                        &DefaultCheckProcessOutput,
+                    )
+                    .map(|_output| ());
+                self.notify(Action::Modify);
+            }
+        } // else mdev is not active
+        res
     }
 
     pub fn invoke<F>(&mut self, action: Action, force: bool, func: F) -> Result<()>

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -380,6 +380,12 @@ impl CheckProcessOutput for CapabilitiesCheckProcessOutput {
         match CalloutScriptCache::parse_script_capabilities(&o) {
             Some(cv) => {
                 debug!(" Script supports versioning: {:?}", cv);
+                if cv.has_action(Action::Unknown) {
+                    warn!("Callout script {:?} provides unknown Action type", p);
+                }
+                if cv.has_event(Event::Unknown) {
+                    warn!("Callout script {:?} provides unknown Event type", p);
+                }
                 c.script = Some(CalloutScriptInfo::new(
                     p,
                     c.dev.parent().unwrap().to_string(),

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::fmt::{self, Display, Formatter};
 use std::io::{ErrorKind, Write};
@@ -8,12 +10,16 @@ use std::process::{Command, Output, Stdio};
 
 use crate::mdev::*;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Event {
     Pre,
     Post,
     Notify,
     Get,
+    #[serde(skip_serializing)]
+    #[serde(other)]
+    Unknown, // used for forward compatibility to newer callout scripts
 }
 
 fn invocation_failure(path: &PathBuf, code: Option<i32>) -> anyhow::Error {
@@ -34,12 +40,13 @@ impl Display for Event {
             Event::Post => write!(f, "post"),
             Event::Notify => write!(f, "notify"),
             Event::Get => write!(f, "get"),
+            Event::Unknown => write!(f, "unknown"),
         }
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Action {
     Start,
     Stop,
@@ -47,7 +54,12 @@ pub enum Action {
     Undefine,
     Modify,
     Attributes,
+    Capabilities,
+    #[serde(skip_serializing)]
     Test, // used for tests only
+    #[serde(skip_serializing)]
+    #[serde(other)]
+    Unknown, // used for forward compatibility to newer callout scripts
 }
 
 impl Display for Action {
@@ -59,9 +71,78 @@ impl Display for Action {
             Action::Undefine => write!(f, "undefine"),
             Action::Modify => write!(f, "modify"),
             Action::Attributes => write!(f, "attributes"),
+            Action::Capabilities => write!(f, "capabilities"),
             Action::Test => write!(f, "test"),
+            Action::Unknown => write!(f, "unknown"),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub struct CalloutVersion {
+    version: Cow<'static, u32>,
+    actions: Cow<'static, [Action]>,
+    events: Cow<'static, [Event]>,
+}
+
+impl CalloutVersion {
+    pub const fn new_const(
+        version: &'static u32,
+        actions: &'static [Action],
+        events: &'static [Event],
+    ) -> Self {
+        Self {
+            version: Cow::Borrowed(version),
+            actions: Cow::Borrowed(actions),
+            events: Cow::Borrowed(events),
+        }
+    }
+
+    pub const V_1: CalloutVersion = CalloutVersion::new_const(
+        &1,
+        &[
+            Action::Start,
+            Action::Stop,
+            Action::Define,
+            Action::Undefine,
+            Action::Modify,
+            Action::Attributes,
+        ],
+        &[Event::Pre, Event::Post, Event::Notify, Event::Get],
+    );
+
+    pub const V_2: CalloutVersion = CalloutVersion::new_const(
+        &2,
+        &[
+            Action::Start,
+            Action::Stop,
+            Action::Define,
+            Action::Undefine,
+            Action::Modify,
+            Action::Attributes,
+            Action::Capabilities,
+        ],
+        &[Event::Pre, Event::Post, Event::Notify, Event::Get],
+    );
+
+    pub fn has_action(&self, action: Action) -> bool {
+        self.actions.contains(&action)
+    }
+
+    pub fn has_event(&self, event: Event) -> bool {
+        self.events.contains(&event)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CalloutVersionProvides {
+    provides: Option<CalloutVersion>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CalloutVersionSupports {
+    supports: Option<CalloutVersion>,
 }
 
 #[derive(Clone, Copy)]
@@ -77,6 +158,159 @@ impl Display for State {
             State::None => write!(f, "none"),
             State::Success => write!(f, "success"),
             State::Failure => write!(f, "failure"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CalloutScriptInfo {
+    path: PathBuf,
+    parent: String,
+    mdev_type: String,
+    supports: CalloutVersion,
+}
+
+impl CalloutScriptInfo {
+    fn new(
+        path: PathBuf,
+        parent: String,
+        mdev_type: String,
+        supports: CalloutVersion,
+    ) -> CalloutScriptInfo {
+        CalloutScriptInfo {
+            path,
+            parent,
+            mdev_type,
+            supports,
+        }
+    }
+
+    fn supports_event_action(&self, event: Event, action: Action) -> Result<()> {
+        if !self.supports.has_action(action) {
+            debug!(
+                "Callout script {:?} does not support action '{:?}'",
+                self.path.clone(),
+                action
+            );
+            return Err(anyhow!(
+                "Script {:?} does not support action '{:?}'",
+                self.path.clone(),
+                action
+            ));
+        }
+        if !self.supports.has_event(event) {
+            debug!(
+                "Callout script {:?} does not support event '{:?}'",
+                self.path.clone(),
+                event
+            );
+            return Err(anyhow!(
+                "Script {:?} does not support event '{:?}'",
+                self.path.clone(),
+                event
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<Path> for CalloutScriptInfo {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[derive(Debug)]
+pub struct CalloutScriptCache {
+    callouts: Vec<CalloutScriptInfo>,
+}
+
+impl CalloutScriptCache {
+    pub const fn new() -> Self {
+        CalloutScriptCache {
+            callouts: Vec::new(),
+        }
+    }
+
+    fn parse_script_capabilities(output: &Output) -> Option<CalloutVersion> {
+        let stdout = String::from_utf8(output.clone().stdout).unwrap();
+        match serde_json::from_str::<CalloutVersionSupports>(stdout.trim_end_matches('\0')) {
+            Ok(ce) => ce.supports.or_else(|| {
+                debug!(" Callout script does not provide version support");
+                None
+            }),
+            Err(e) => {
+                debug!(
+                    " Callout script has no version support (unparsable stdout): {:?}",
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    fn lookup_callout_script(&self, parent: &str, mdev_type: &str) -> Option<CalloutScriptInfo> {
+        self.callouts
+            .iter()
+            .find(|cs| cs.mdev_type == mdev_type && cs.parent == parent)
+            .cloned()
+    }
+
+    pub fn find_versioned_script(&mut self, dev: &MDev) -> Option<CalloutScriptInfo> {
+        // check already found scripts
+        let mut dev = dev.clone();
+        let mut callout = callout(&mut dev);
+        let mdev_type = match callout.dev.mdev_type() {
+            Ok(t) => t.clone(),
+            Err(_) => {
+                debug!("mdev_type is required on device => cannot find a callout script");
+                return None;
+            }
+        };
+        let parent = match callout.dev.parent() {
+            Ok(p) => p.clone(),
+            Err(_) => {
+                debug!("parent is required on device => cannot find a callout script");
+                return None;
+            }
+        };
+        debug!("Looking up callout script for mdev type '{:?}'", mdev_type);
+        match self.lookup_callout_script(&parent, &mdev_type) {
+            Some(cs) => {
+                debug!(
+                    "Looked up callout script for mdev type '{:?}' and parent {:?}: {:?}",
+                    mdev_type, parent, cs.path
+                );
+                return Some(cs);
+            }
+            None => {
+                debug!(
+                    "Callout script lookup failed. Start searching for mdev type '{:?}' and parent {:?}",
+                    mdev_type, parent
+                );
+            }
+        }
+
+        let ce_ver = CalloutVersionProvides {
+            provides: Some(CalloutVersion::V_2),
+        };
+        let json_ce_ver =
+            serde_json::to_string(&ce_ver).expect("CalloutVersion JSON could not be generated");
+
+        match callout.callout(
+            Event::Get,
+            Action::Capabilities,
+            Some(&json_ce_ver),
+            &CapabilitiesCheckProcessOutput,
+        ) {
+            Ok(op) => match op {
+                Some(_) => {
+                    self.callouts.push(callout.script.clone().unwrap());
+                    callout.script
+                }
+                None => None,
+            },
+            Err(_) => None,
         }
     }
 }
@@ -97,7 +331,12 @@ impl CheckProcessOutput for DefaultCheckProcessOutput {
         c.print_err(&o, &p);
         match o.status.code() {
             Some(0) => {
-                c.script = Some(p);
+                c.script = Some(CalloutScriptInfo::new(
+                    p,
+                    c.dev.parent().unwrap().to_string(),
+                    c.dev.mdev_type().unwrap().to_string(),
+                    CalloutVersion::V_1,
+                ));
                 Ok(Some(o))
             }
             Some(n) => Err(invocation_failure(&p, Some(n))),
@@ -106,9 +345,40 @@ impl CheckProcessOutput for DefaultCheckProcessOutput {
     }
 }
 
+struct CapabilitiesCheckProcessOutput;
+
+impl CheckProcessOutput for CapabilitiesCheckProcessOutput {
+    fn check(&self, p: PathBuf, o: Output) -> Result<(PathBuf, Output)> {
+        match CalloutScriptCache::parse_script_capabilities(&o) {
+            Some(_) => Ok((p, o)),
+            None => Err(anyhow!(
+                "Output of callout script {:?} is not a valid capabilities XML response",
+                p
+            )),
+        }
+    }
+
+    fn process(&self, c: &mut Callout<'_, '_>, p: PathBuf, o: Output) -> Result<Option<Output>> {
+        c.print_err(&o, &p);
+        match CalloutScriptCache::parse_script_capabilities(&o) {
+            Some(cv) => {
+                debug!(" Script supports versioning: {:?}", cv);
+                c.script = Some(CalloutScriptInfo::new(
+                    p,
+                    c.dev.parent().unwrap().to_string(),
+                    c.dev.mdev_type().unwrap().to_string(),
+                    cv,
+                ));
+                Ok(Some(o))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
 pub struct Callout<'a, 'b> {
     state: State,
-    script: Option<PathBuf>,
+    script: Option<CalloutScriptInfo>,
     pub dev: &'b mut MDev<'a>,
 }
 
@@ -128,10 +398,19 @@ impl<'a, 'b> Callout<'a, 'b> {
         }
     }
 
+    fn find_callout_script(&self) -> Option<CalloutScriptInfo> {
+        self.dev.env.find_script(self.dev)
+    }
+
     pub fn invoke<F>(&mut self, action: Action, force: bool, func: F) -> Result<()>
     where
         F: Fn(&mut Self) -> Result<()>,
     {
+        self.script = self.find_callout_script();
+        if self.script.is_none() {
+            debug!("No callout script with version support found");
+        }
+
         let conf = self.dev.to_json(false)?.to_string();
         let res = self
             .callout(Event::Pre, action, Some(&conf), &DefaultCheckProcessOutput)
@@ -167,6 +446,11 @@ impl<'a, 'b> Callout<'a, 'b> {
     }
 
     pub fn get_attributes(&mut self) -> Result<serde_json::Value> {
+        self.script = self.find_callout_script();
+        if self.script.is_none() {
+            debug!("No callout script with version support found");
+        }
+
         match self.callout(
             Event::Get,
             Action::Attributes,
@@ -201,7 +485,7 @@ impl<'a, 'b> Callout<'a, 'b> {
                     serde_json::from_str(st.trim_end_matches('\0'))
                         .with_context(|| "Invalid JSON received from callout script")
                 } else {
-                    let path = self.script.as_ref().unwrap();
+                    let path = &self.script.as_ref().unwrap().path;
                     self.print_err(&output, path);
 
                     Err(invocation_failure(path, output.status.code()))
@@ -352,11 +636,12 @@ impl<'a, 'b> Callout<'a, 'b> {
     ) -> Result<Option<Output>> {
         match self.script {
             Some(ref s) => {
+                s.supports_event_action(event, action)?;
                 let output = self.invoke_script(s, event, action, stdin)?;
                 self.print_err(&output, s);
                 match output.status.code() {
                     None | Some(0) => Ok(Some(output)),
-                    Some(n) => Err(invocation_failure(self.script.as_ref().unwrap(), Some(n))),
+                    Some(n) => Err(invocation_failure(&s.path, Some(n))),
                 }
             }
             None => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,6 +172,16 @@ pub enum MdevctlCommands {
         )]
         manual: bool,
         #[arg(
+            short,
+            long,
+            conflicts_with_all(&["type", "index", "value"]),
+            requires("jsonfile"),
+            help = "Modify the running device definition only unless used together with defined option"
+        )]
+        live: bool,
+        #[arg(short, long, help = "Modify the stored device definition")]
+        defined: bool,
+        #[arg(
             long,
             conflicts_with_all(&["type", "index", "value"]),
             help = "Specify device details in JSON format"

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,28 +225,75 @@ fn modify_command(
     value: Option<String>,
     auto: bool,
     manual: bool,
+    live: bool,
+    defined: bool,
     jsonfile: Option<PathBuf>,
     force: bool,
 ) -> Result<()> {
-    let mut dev = get_defined_device(env, uuid, parent.as_ref())?;
-
-    if let Some(f) = jsonfile {
-        let parent = parent
-            .ok_or_else(|| anyhow!("Parent device required to modify device via json file"))?;
-        dev = dev_from_jsonfile(env, uuid, parent, f)?;
-    } else {
+    debug!("Modifying mdev {:?}", uuid);
+    if live {
         if mdev_type.is_some() {
-            dev.mdev_type = mdev_type;
+            return Err(anyhow!("'type' cannot be changed on active mdev"));
         }
-
-        if auto && manual {
-            return Err(anyhow!("'auto' and 'manual' are mutually exclusive"));
-        }
-
         if auto {
-            dev.autostart = true;
-        } else if manual {
-            dev.autostart = false;
+            return Err(anyhow!("'auto' cannot be changed on active mdev"));
+        }
+        if manual {
+            return Err(anyhow!("'manual' cannot be changed on active mdev"));
+        }
+        let mut act_dev = get_active_device(env, uuid, parent.as_ref())?;
+        if let Some(f) = jsonfile {
+            let act_parent = act_dev
+                .parent
+                .clone()
+                .ok_or_else(|| anyhow!("Parent device required to modify device via json file"))?;
+            let json_dev = dev_from_jsonfile(env, uuid, act_parent, f)?;
+            if json_dev.mdev_type != act_dev.mdev_type {
+                return Err(anyhow!("'type' cannot be changed on active mdev"));
+            }
+            if json_dev.parent != act_dev.parent {
+                return Err(anyhow!("'parent' cannot be changed on active mdev"));
+            }
+            act_dev = json_dev;
+        } else {
+            return Err(anyhow!("'live' option must be used with 'jsonfile' option"));
+        }
+
+        if defined {
+            // live and stored modify - defined dev config exists and types match
+            let def_dev = get_defined_device(env, uuid, act_dev.parent.as_ref())?;
+            if def_dev.mdev_type != act_dev.mdev_type {
+                return Err(anyhow!("'type' of active and defined mdev does not match"));
+            }
+
+            let mut c = callout(&mut act_dev);
+            debug!("mdev device used for live update '{:?}'", c.dev);
+            return c
+                .invoke_modify_live()
+                .and_then(|_| c.invoke(Action::Modify, force, |c| c.dev.write_config()));
+        }
+        // live modify only
+        callout(&mut act_dev).invoke_modify_live()
+    } else {
+        let mut dev: MDev;
+        // stored configuration modify
+        if let Some(f) = jsonfile {
+            let parent = parent
+                .ok_or_else(|| anyhow!("Parent device required to modify device via json file"))?;
+            dev = dev_from_jsonfile(env, uuid, parent, f)?;
+        } else {
+            dev = get_defined_device(env, uuid, parent.as_ref())?;
+            if mdev_type.is_some() {
+                dev.mdev_type = mdev_type;
+            }
+            if auto && manual {
+                return Err(anyhow!("'auto' and 'manual' are mutually exclusive"));
+            }
+            if auto {
+                dev.autostart = true;
+            } else if manual {
+                dev.autostart = false;
+            }
         }
 
         let index = index.map(|n| n as usize);
@@ -261,9 +308,8 @@ fn modify_command(
                 }
             }
         }
+        callout(&mut dev).invoke(Action::Modify, force, |c| c.dev.write_config())
     }
-
-    callout(&mut dev).invoke(Action::Modify, force, |c| c.dev.write_config())
 }
 
 /// convert 'start' command arguments into a MDev struct
@@ -507,6 +553,43 @@ fn defined_devices<'a>(
         }
     }
     Ok(devices)
+}
+
+/// convenience function to lookup an active device by uuid and parent
+fn get_active_device<'a>(
+    env: &'a dyn Environment,
+    uuid: Uuid,
+    parent: Option<&String>,
+) -> Result<MDev<'a>> {
+    let devs = active_devices(env, Some(&uuid), parent)?;
+    if devs.is_empty() {
+        match parent {
+            None => Err(anyhow!(
+                "Mediated device {} is not active",
+                uuid.hyphenated().to_string()
+            )),
+            Some(p) => Err(anyhow!(
+                "Mediated device {}/{} is not active",
+                p,
+                uuid.hyphenated().to_string()
+            )),
+        }
+    } else if devs.len() > 1 {
+        Err(anyhow!(
+            "Multiple parents found for {}. System error?",
+            uuid.hyphenated().to_string()
+        ))
+    } else {
+        let (parent, children) = devs.iter().next().unwrap();
+        if children.len() > 1 {
+            return Err(anyhow!(
+                "Multiple definitions found for {}/{}",
+                parent,
+                uuid.hyphenated().to_string()
+            ));
+        }
+        Ok(children.first().unwrap().clone())
+    }
 }
 
 /// Get a map of all active devices, optionally filtered by uuid and parent
@@ -851,11 +934,13 @@ fn main() -> Result<()> {
                 value,
                 auto,
                 manual,
+                live,
+                defined,
                 jsonfile,
                 force,
             } => modify_command(
-                &env, uuid, parent, mdev_type, addattr, delattr, index, value, auto, manual,
-                jsonfile, force,
+                &env, uuid, parent, mdev_type, addattr, delattr, index, value, auto, manual, live,
+                defined, jsonfile, force,
             ),
             MdevctlCommands::Start {
                 uuid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,7 +407,7 @@ fn get_defined_device<'a>(
                 uuid.hyphenated().to_string()
             ));
         }
-        Ok(children.get(0).unwrap().clone())
+        Ok(children.first().unwrap().clone())
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -681,6 +681,8 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
+        false,
+        false,
         jsonfile,
         force,
     );

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -652,6 +652,8 @@ fn test_modify_helper<F>(
     value: Option<String>,
     auto: bool,
     manual: bool,
+    live: bool,
+    defined: bool,
     jsonfile: Option<PathBuf>,
     force: bool,
     setupfn: F,
@@ -681,8 +683,8 @@ fn test_modify_helper<F>(
         value,
         auto,
         manual,
-        false,
-        false,
+        live,
+        defined,
         jsonfile,
         force,
     );
@@ -698,6 +700,81 @@ fn test_modify_helper<F>(
     assert!(def.is_defined());
     let filecontents = fs::read_to_string(&path).unwrap();
     test.compare_to_file(&format!("{}.expected", testname), &filecontents);
+}
+
+fn test_modify_defined_active_helper<F>(
+    testname: &str,
+    expect: Expect,
+    uuid: &str,
+    parent: Option<String>,
+    mdev_type: Option<String>,
+    addattr: Option<String>,
+    delattr: bool,
+    index: Option<u32>,
+    value: Option<String>,
+    auto: bool,
+    manual: bool,
+    live: bool,
+    defined: bool,
+    jsonfile: Option<PathBuf>,
+    force: bool,
+    setupfn: F,
+) where
+    F: Fn(&TestEnvironment),
+{
+    use crate::modify_command;
+    let test = TestEnvironment::new("modify", testname);
+
+    // load the jsonfile from the test path.
+    let jsonfile = match jsonfile {
+        Some(f) => Some(test.datapath.join(f)),
+        None => None,
+    };
+
+    setupfn(&test);
+
+    let uuid = Uuid::parse_str(uuid).unwrap();
+    let result = modify_command(
+        &test,
+        uuid,
+        parent.clone(),
+        mdev_type,
+        addattr,
+        delattr,
+        index,
+        value,
+        auto,
+        manual,
+        live,
+        defined,
+        jsonfile,
+        force,
+    );
+    if test
+        .assert_result(result, expect, Some("modify command"))
+        .is_err()
+    {
+        return;
+    }
+
+    let def_active = crate::get_active_device(&test, uuid, parent.as_ref())
+        .expect("Couldn't find defined device");
+    assert!(def_active.active);
+    let def_json = serde_json::to_string_pretty(
+        &def_active
+            .to_json(false)
+            .expect("Couldn't get json from active device"),
+    )
+    .expect("Couldn't get json from active device");
+    test.compare_to_file(&format!("{}.active.expected", testname), &def_json);
+
+    let def = crate::get_defined_device(&test, uuid, parent.as_ref())
+        .expect("Couldn't find defined device");
+    let path = def.persist_path().unwrap();
+    assert!(path.exists());
+    assert!(def.is_defined());
+    let filecontents = fs::read_to_string(&path).unwrap();
+    test.compare_to_file(&format!("{}.defined.expected", testname), &filecontents);
 }
 
 #[test]
@@ -718,6 +795,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         None,
         false,
         |_| {},
@@ -733,6 +812,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         false,
@@ -752,6 +833,8 @@ fn test_modify() {
         None,
         false,
         true,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -768,6 +851,8 @@ fn test_modify() {
         true,
         Some(2),
         None,
+        false,
+        false,
         false,
         false,
         None,
@@ -788,6 +873,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -804,6 +891,8 @@ fn test_modify() {
         false,
         Some(3),
         Some("added-attr-value".to_string()),
+        false,
+        false,
         false,
         false,
         None,
@@ -824,6 +913,8 @@ fn test_modify() {
         Some("added-attr-value".to_string()),
         false,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -840,6 +931,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         None,
@@ -860,6 +953,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -878,6 +973,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         false,
@@ -898,6 +995,8 @@ fn test_modify() {
         None,
         true,
         true,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -915,6 +1014,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         Some(PathBuf::from("modified.json")),
@@ -936,6 +1037,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -956,6 +1059,8 @@ fn test_modify() {
         None,
         true,
         false,
+        false,
+        false,
         None,
         false,
         |test| {
@@ -975,6 +1080,8 @@ fn test_modify() {
         None,
         None,
         true,
+        false,
+        false,
         false,
         None,
         true,
@@ -999,6 +1106,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1018,6 +1127,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1035,6 +1146,8 @@ fn test_modify() {
         false,
         None,
         None,
+        false,
+        false,
         false,
         false,
         Some(PathBuf::from("modified.json")),
@@ -1057,6 +1170,8 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
@@ -1077,12 +1192,200 @@ fn test_modify() {
         None,
         false,
         false,
+        false,
+        false,
         Some(PathBuf::from("modified.json")),
         false,
         |test| {
             test.populate_defined_device(UUID_VER, PARENT, "defined.json");
             test.populate_callout_script("rc0.sh"); // no versioning
             test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_NO_LIVE: &str = "11111111-1111-0000-0000-000000000000";
+    const UUID_LIVE: &str = "11111111-1111-1111-0000-000000000000";
+
+    test_modify_helper(
+        "live-event-supported",
+        Expect::Pass,
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-event-unsupported-by-callout",
+        Expect::Fail(None),
+        UUID_NO_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_NO_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_NO_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-unsupported-script-without-version-support",
+        Expect::Fail(Some(
+            format!("'live' option must be used with 'jsonfile' option").as_str(),
+        )),
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_active_device(UUID, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+    test_modify_helper(
+        "live-supported-but-fails",
+        Expect::Fail(None),
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc1.sh");
+        },
+    );
+    test_modify_helper(
+        "live-fail-without-jsonfile",
+        Expect::Fail(Some(
+            format!("'live' option must be used with 'jsonfile' option").as_str(),
+        )),
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        false,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("live-rc0.sh");
+        },
+    );
+
+    test_modify_defined_active_helper(
+        "live-defined-supported",
+        Expect::Pass,
+        UUID_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        true,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
+        },
+    );
+    test_modify_defined_active_helper(
+        "live-defined-live-event-unsupported",
+        Expect::Fail(None),
+        UUID_NO_LIVE,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        true,
+        true,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_NO_LIVE, PARENT, "defined.json");
+            test.populate_active_device(UUID_NO_LIVE, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
+        },
+    );
+    test_modify_defined_active_helper(
+        "defined-only",
+        Expect::Pass,
+        UUID,
+        Some(PARENT.to_string()),
+        None,
+        Some("added-attr".to_string()),
+        false,
+        None,
+        Some("added-attr-value".to_string()),
+        false,
+        false,
+        false,
+        true,
+        None,
+        false,
+        |test| {
+            test.populate_defined_device(UUID, PARENT, "defined.json");
+            test.populate_active_device(UUID, PARENT, "vfio_ap-passthrough");
+            test.populate_callout_script("modify-active.sh");
         },
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use tempfile::Builder;
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -33,11 +34,20 @@ struct TestEnvironment {
     scratch: TempDir,
     name: String,
     case: String,
+    callout_scripts: Mutex<CalloutScriptCache>,
 }
 
 impl Environment for TestEnvironment {
     fn root(&self) -> &Path {
         self.scratch.path()
+    }
+
+    fn find_script(&self, dev: &MDev) -> Option<CalloutScriptInfo> {
+        return self
+            .callout_scripts
+            .lock()
+            .unwrap()
+            .find_versioned_script(dev);
     }
 }
 
@@ -50,6 +60,7 @@ impl TestEnvironment {
             scratch: scratchdir,
             name: testname.to_owned(),
             case: testcase.to_owned(),
+            callout_scripts: Mutex::new(CalloutScriptCache::new()),
         };
         // populate the basic directories in the environment
         fs::create_dir_all(test.mdev_base()).expect("Unable to create mdev_base");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -577,6 +577,67 @@ fn test_define() {
             test.populate_callout_script("rc1.sh");
         },
     );
+
+    // test define with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    test_define_command_callout(
+        "define-with-version-callout-all-pass",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-all-fail",
+        Expect::Fail(None),
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_define_command_callout(
+        "define-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        Uuid::parse_str("11111111-1111-0000-0000-000000000000").ok(),
+        Some(DEFAULT_PARENT.to_string()),
+        Some("i915-GVTg_V5_4".to_string()),
+        false,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_modify_helper<F>(
@@ -920,6 +981,108 @@ fn test_modify() {
             test.populate_callout_script("rc1.sh");
         },
     );
+
+    // test modify with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_modify_helper(
+        "modify-jsonfile-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        None,
+        None,
+        false,
+        None,
+        None,
+        false,
+        false,
+        Some(PathBuf::from("modified.json")),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_undefine_helper<F>(
@@ -1034,6 +1197,68 @@ fn test_undefine() {
         |test| {
             test.populate_defined_device(UUID, PARENT, "defined.json");
             test.populate_callout_script("rc1.sh");
+        },
+    );
+
+    // test define with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_undefine_helper(
+        "undefine-single-with-version-callout-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "undefine-single-with-version-callout-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_undefine_helper(
+        "define-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        Some(PARENT.to_string()),
+        false,
+        |test| {
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
         },
     );
 }
@@ -1385,6 +1610,78 @@ fn test_start() {
     // TODO: test attributes -- difficult because executing the 'start' command by writing to
     // the 'create' file in sysfs does not automatically create the device file structure in
     // the temporary test environment, so writing the sysfs attribute files fails.
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_start_command_callout(
+        "start-single-with-version-callout-pass",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-single-with-version-callout-fail",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-pass",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-pass2",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc1.sh"); // no versioning error
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_start_command_callout(
+        "start-with-version-callout-multiple-with-version-fail",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).ok(),
+        Some(PARENT.to_string()),
+        Some(MDEV_TYPE.to_string()),
+        false,
+        |test| {
+            test.populate_parent_device(PARENT, MDEV_TYPE, 1, "vfio-pci", "test device", None);
+            test.populate_defined_device(UUID_VER, PARENT, "defined.json");
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
 }
 
 fn test_stop_helper<F>(testname: &str, expect: Expect, uuid: &str, force: bool, setupfn: F)
@@ -1427,6 +1724,52 @@ fn test_stop() {
         t.populate_active_device(UUID, PARENT, MDEV_TYPE);
         t.populate_callout_script("rc1.sh")
     });
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    test_stop_helper(
+        "stop-single-callout-with-version-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callout-with-version-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("ver-rc1.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callouts-mix-all-pass",
+        Expect::Pass,
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_stop_helper(
+        "stop-single-callouts-mix-all-fail",
+        Expect::Fail(None),
+        UUID_VER,
+        false,
+        |test| {
+            test.populate_active_device(UUID_VER, PARENT, MDEV_TYPE);
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning
+        },
+    );
 }
 
 #[test]
@@ -2106,6 +2449,191 @@ fn test_callouts() {
         DEFAULT_TYPE,
         |test| {
             test.populate_callout_script("good-json-null-terminated.sh");
+        },
+    );
+
+    // test start with versioning callouts
+    // uuid=11111111-1111-0000-0000-000000000000 has a supported version
+    const UUID_VER: &str = "11111111-1111-0000-0000-000000000000";
+    const UUID_VER_RC1: &str = "11111111-1111-0000-0000-111111111111";
+    const UUID_VER_RC2: &str = "11111111-1111-0000-0000-222222222222";
+    const UUID_VER_BAD_JSON: &str = "11111111-1111-0000-0000-aaaaaaaaaaaa";
+    const UUID_VER_ACTION_DUMMY: &str = "11111111-1111-0000-0000-bbbbbbbbbbbb";
+    const UUID_VER_EVENT_DUMMY: &str = "11111111-1111-0000-0000-cccccccccccc";
+    const UUID_VER_MODIFY_MISSING: &str = "11111111-1111-0000-0000-dddddddddddd";
+    const UUID_VER_PROVIDES: &str = "11111111-1111-0000-0000-eeeeeeeeeeee";
+    const UUID_VER_INVALID_JSON: &str = "11111111-1111-0000-0000-ffffffffffff";
+
+    test_invoke_callout(
+        "test_callout_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_mix_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_mix_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc0.sh"); // no versioning
+            test.populate_callout_script("ver-rc1.sh"); // versioning error
+        },
+    );
+    test_get_callout(
+        "test_callout_with_version_good_json",
+        Expect::Pass,
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_get_callout(
+        "test_callout_with_version_bad_json",
+        Expect::Fail(None),
+        Uuid::parse_str(UUID_VER).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0-get-attr-bad-json.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_get_capabilities_rc1_run_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_RC1).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_get_capabilities_rc2_run_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_RC2).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_get_capabilities_bad_run_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_BAD_JSON).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_unknown_action_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_ACTION_DUMMY).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_unknown_event_with_verion_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_EVENT_DUMMY).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_missing_modify_run_start_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_MODIFY_MISSING).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_missing_modify_run_modify_fail",
+        Expect::Fail(None),
+        Action::Modify,
+        Uuid::parse_str(UUID_VER_MODIFY_MISSING).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_json_provides_with_version_pass",
+        Expect::Pass,
+        Action::Start,
+        Uuid::parse_str(UUID_VER_PROVIDES).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
+        },
+    );
+    test_invoke_callout(
+        "test_callout_with_version_json_invalid_with_version_without_version_fail",
+        Expect::Fail(None),
+        Action::Start,
+        Uuid::parse_str(UUID_VER_INVALID_JSON).unwrap(),
+        DEFAULT_PARENT,
+        DEFAULT_TYPE,
+        |test| {
+            test.populate_callout_script("rc1.sh"); // no versioning
+            test.populate_callout_script("ver-rc0.sh"); // versioning
         },
     );
 }

--- a/tests/callouts/live-rc0.sh
+++ b/tests/callouts/live-rc0.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 3 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":3,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            *)
+                exit 0
+            ;;
+        esac
+    ;;
+    live)
+        exit 0
+    ;;
+    *)
+        exit 0
+    ;;
+esac

--- a/tests/callouts/live-rc1.sh
+++ b/tests/callouts/live-rc1.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 3 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":3,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            *)
+                exit 0
+            ;;
+        esac
+    ;;
+    live)
+        exit 1
+    ;;
+    *)
+        exit 0
+    ;;
+esac

--- a/tests/callouts/modify-active.sh
+++ b/tests/callouts/modify-active.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# A basic utility script used for debugging notification call-out events
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+tempfile="tmp_modify-live.json"
+
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-1111-0000-000000000000)
+            # valid version 3 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":3,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"live\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    pre)
+        case "$action" in
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version "$uuid"
+            ;;
+            attributes)
+                if [ -f "$tempfile" ]; then
+                    cat "$tempfile"
+                    rm "$tempfile"
+                else
+                        echo "[]"
+                fi
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    post)
+        case "$action" in
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    live)
+        case "$action" in
+            modify)
+                echo "$json" | grep -oP '"attrs":+\K(\[.*\])' > "$tempfile"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/ver-rc0-get-attr-bad-json.sh
+++ b/tests/callouts/ver-rc0-get-attr-bad-json.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-222222222222)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":\111111,"
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 2
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "not json"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/ver-rc0.sh
+++ b/tests/callouts/ver-rc0.sh
@@ -1,0 +1,171 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-222222222222)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":111111,"
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "[{\"attribute0\": \"VALUE\"}]"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    pre)
+        case "$action" in
+            define)
+                exit 0
+            ;;
+            undefine)
+                exit 0
+            ;;
+            start)
+                exit 0
+            ;;
+            stop)
+                exit 0
+            ;;
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    post)
+        case "$action" in
+            define)
+                exit 0
+            ;;
+            undefine)
+                exit 0
+            ;;
+            start)
+                exit 0
+            ;;
+            stop)
+                exit 0
+            ;;
+            modify)
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/callouts/ver-rc1.sh
+++ b/tests/callouts/ver-rc1.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# A basic utility script used for debugging versioning of call-out scripts
+# in mdevctl. Output can be observed via system logs.
+
+#stdin | -t type -e event -a action -s state -u uuid -p parent
+shift
+type=$1
+shift 2
+event=$1
+shift 2
+action=$1
+shift 2
+state=$1
+shift 2
+uuid=$1
+shift 2
+parent=$1
+json=$(cat)
+
+print_supported_version() {
+    case "$1" in
+        11111111-1111-0000-0000-000000000000)
+            # full version 2 and RC=0
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=1
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 1
+        ;;
+        11111111-1111-0000-0000-111111111111)
+            # valid json with RC=2
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 2
+        ;;
+        11111111-1111-0000-0000-aaaaaaaaaaaa)
+            # no json output at all
+            echo "This output is bad"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-bbbbbbbbbbbb)
+            # extra action dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\",\"dummy\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-cccccccccccc)
+            # extra event dummy
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\",\"dummy\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-dddddddddddd)
+            # action modify missing
+            echo "{\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-eeeeeeeeeeee)
+            # extra valid data contained
+            echo "{\"provides\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "},\"supports\":{"
+            echo "\"version\":2,"
+            echo "\"actions\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"events\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        11111111-1111-0000-0000-ffffffffffff)
+            # invalid json
+            echo "{\"supports\":{{{"
+            echo "\"version\":111111,"
+            echo "\"actors\":[\"start\",\"stop\",\"define\",\"undefine\",\"modify\",\"attributes\",\"capabilities\"],"
+            echo "\"inventors\":[\"pre\",\"post\",\"notify\",\"get\"]"
+            echo "}}"
+            exit 0
+        ;;
+        *)
+            exit 1
+        ;;
+    esac
+}
+
+case "$event" in
+    get)
+        case "$action" in
+            capabilities)
+                print_supported_version $uuid
+            ;;
+            attributes)
+                echo "[{\"attribute0\": \"VALUE\"}]"
+                exit 0
+            ;;
+            *)
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        exit 1
+    ;;
+esac

--- a/tests/modify/defined-only.active.expected
+++ b/tests/modify/defined-only.active.expected
@@ -1,0 +1,5 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": []
+}

--- a/tests/modify/defined-only.defined.expected
+++ b/tests/modify/defined-only.defined.expected
@@ -1,0 +1,27 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    },
+    {
+      "added-attr": "added-attr-value"
+    }
+  ]
+}

--- a/tests/modify/live-defined-supported.active.expected
+++ b/tests/modify/live-defined-supported.active.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/live-defined-supported.defined.expected
+++ b/tests/modify/live-defined-supported.defined.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/live-event-supported.expected
+++ b/tests/modify/live-event-supported.expected
@@ -1,0 +1,24 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "manual",
+  "attrs": [
+    {
+      "assign_adapter": "5"
+    },
+    {
+      "assign_adapter": "6"
+    },
+    {
+      "assign_domain": "0xab"
+    },
+    {
+      "assign_control_domain": "0xab"
+    },
+    {
+      "assign_domain": "4"
+    },
+    {
+      "assign_control_domain": "4"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-all-pass.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-all-pass.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}

--- a/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass2.expected
+++ b/tests/modify/modify-jsonfile-with-version-callout-multiple-with-version-pass2.expected
@@ -1,0 +1,15 @@
+{
+  "mdev_type": "vfio_ap-passthrough",
+  "start": "auto",
+  "attrs": [
+    {
+      "assign_adapter": "0x04"
+    },
+    {
+      "assign_domain": "0x0005"
+    },
+    {
+      "assign_control_domain": "0x0005"
+    }
+  ]
+}


### PR DESCRIPTION
The first patch fixes a clippy warning encountered on github.
The next six patches are callout version support related.
The fifth patch adds code preventing repeating callouts when version lookup failed before addressing a comment I made in v3.
The last six patches add live modify support exploiting the callout version support.

Changes in v6:
    Inlined supports_action and supports_event
    Renamed CalloutExport/Import into CalloutVersionProvides/Supports
    Fixuped callouts: lookup_callout_script more rustified
    Changed lookup_callout_script to use simple string compare

Changes in v5:
    Rewrote the manpage to better work out the expectation wrt the versioning JSON exchange.
    Split CalloutExchange into CalloutExport and CalloutImport and removed skip_serializing_if.
    Renamed CalloutScript into CalloutScriptInfo.
    Renamed CalloutScripts into CalloutScriptCache.
    Provided a new rusty implementation of lookup_callout_script.
    Rename method find_script into find_versioned_script.