### PR TITLE
Fix clippy problem on master

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -165,7 +165,7 @@ pub trait Environment: std::fmt::Debug {
 
                     // retrieve autostart from persisted mdev if possible
                     let mut per_dev = MDev::new(self.clone().as_env(), u);
-                    per_dev.parent = dev.parent.clone();
+                    per_dev.parent.clone_from(&dev.parent);
                     if per_dev.load_definition().is_ok() {
                         dev.autostart = per_dev.autostart;
                     }


### PR DESCRIPTION
Fixing this error reported in the CI:
 error: assigning the result of `Clone::clone()` may be inefficient
    --> src/environment.rs:168:21
     |
 168 |                     per_dev.parent = dev.parent.clone();
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `per_dev.parent.clone_from(&dev.parent)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
     = note: `-D clippy::assigning-clones` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`

 error: could not compile `mdevctl` (bin "mdevctl") due to 1 previous error
 Error: Process completed with exit code 101.