### PR TITLE
Update nix dev-dependency to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ clap_complete = "4.0"
 uuid = "1.0"
 
 [dev-dependencies]
-nix = "0.26"
+nix = { version = "0.31", features = ["process"] }
 libc = "0.2"
 tempfile = "3"


### PR DESCRIPTION
https://github.com/nix-rust/nix/blob/v0.31.2/CHANGELOG.md

No source-code changes appear to be required, although I did have to explicitly enable a feature. I tested this by running `cargo test`.

The motivation is that, in Fedora, we’re trying to reduce dependencies on our `rust-nix0.26` compat package, for reasons described in the [downstream issue](https://forge.fedoraproject.org/rust/backlog/issues/7), and it’s our policy to [offer such changes upstream](https://docs.fedoraproject.org/en-US/package-maintainers/Staying_Close_to_Upstream_Projects).